### PR TITLE
Fix multiple flash messages

### DIFF
--- a/src/boss/boss_flash.erl
+++ b/src/boss/boss_flash.erl
@@ -6,7 +6,7 @@ get_and_clear(Req) ->
 		undefined -> [];
 		BossFlash ->
 			boss_session:remove_session_data(Req, boss_flash),
-			[{boss_flash, BossFlash}]
+			[{boss_flash, lists:reverse(BossFlash)}]
 	end.
 
 add(Req, Type, Title) ->


### PR DESCRIPTION
Hi,

This patch fixes the issue with multiple flash messages: when boss_flash:add() is called more than once in a controller only the first message is shown always and the rest is silently dropped.

Probably it makes sense to update the API docs: instead of

{% if boss_flash %} {{ boss_flash.method }} - {{ boss_flash.title }} - {{ boss_flash.message }} {% endif %} 

there should be

{% for msg in boss_flash %} {{ msg.method }} - {{ msg.title }} - {{ msg.message }} {% endfor %} 

Dmitry
