### PR TITLE
More work

### DIFF
--- a/skel/admin/view/big_red_button.html
+++ b/skel/admin/view/big_red_button.html
@@ -1,5 +1,5 @@
 {% extends "view/layouts/admin.html" %}
-{% block title %}{% trans "International Command Center: Big Red Button" %}{% endblock %}
+{% block title %}International Command Center: Big Red Button{% endblock %}
 
 {% block left_submenu %}
 	{% include "view/shared/_lang_left_submenu.html" with automatic_translator="true" %}

--- a/skel/admin/view/create_lang.html
+++ b/skel/admin/view/create_lang.html
@@ -1,5 +1,5 @@
 {% extends "view/layouts/admin.html" %}
-{% block title %}{% trans "Create a language file" %}{% endblock %}
+{% block title %}Create a language file{% endblock %}
 
 {% block left_submenu %}
 	{% include "view/shared/_lang_left_submenu.html" with new_language="true" %}
@@ -49,12 +49,12 @@
 </script>
 {% endblock %}
 {% block body %}
-<h1>{% trans "Create a new language" %}</h1>
+<h1>Create a new language</h1>
 <form method="post" class="tabular">
 	<div class="box">
 		<div id="issue_descr_fields">
 		<p>
-			<label for="issue_tracker_id">{% trans "Select the language" %}<span class="required"> *</span></label>
+			<label for="issue_tracker_id">Select the language<span class="required"> *</span></label>
 			<select id="select_language" name="language" style="width: 120px;"></select>
 		</p>
 		</div>

--- a/skel/admin/view/error.html
+++ b/skel/admin/view/error.html
@@ -3,7 +3,7 @@
         <title>Oops!</title>
     </head>
     <body>
-        <h1><em>{% trans "We got a problem!" %}</em></h1>
+        <h1><em>We got a problem!</em></h1>
         {% for filename, error in errors %}
         <p><em>In file</em> {{ filename }}:</p>
         <ul>

--- a/skel/admin/view/index.html
+++ b/skel/admin/view/index.html
@@ -1,35 +1,35 @@
 {% extends "view/layouts/admin.html" %}
-{% block title %}{% trans "General Info" %}{% endblock %}
+{% block title %}General Info{% endblock %}
 
 {% block right_submenu %}
 	<ul>
-		<li><a href="http://www.chicagoboss.org">{% trans "ChicagoBoss Community Home" %}</a></li>
+		<li><a href="http://www.chicagoboss.org">ChicagoBoss Community Home</a></li>
 	</ul>
 {% endblock %}
 
 {% block body %}
-<h1>{% trans "Welcome to the Admin Interface" %}</h1>
+<h1>Welcome to the Admin Interface</h1>
 
-<h2>{% trans "System Info" %}</h2>
+<h2>System Info</h2>
 <ul>
 	<li><b>Erlang OTP Release:</b> {{ system_env.otp_release }}</li>
 	<li><b>Processors:</b> {{ system_env.processors }}</li>
 </ul>
 
-<h2>{% trans "Applications loaded" %}</h2>
+<h2>Applications loaded</h2>
 <ul>
 {% for module in modules_loaded %}
 	<li>{{ module }}</li>
 {% endfor %}
 </ul>
 
-<h2>{% trans "Application configuration Info" %}</h2>
+<h2>Application configuration Info</h2>
 <ul>
 {% for envs in config_env %}
 	<li>{{ envs }}</li>
 {% endfor %}
 </ul>
 
-<p>{% trans "See the loaded routes" %} <a class="routes" href="{{ _base_url }}/admin/routes">{% trans "here" %}</a>
+<p>See the loaded routes <a class="routes" href="{{ _base_url }}/admin/routes">here</a>
 
 {% endblock %}

--- a/skel/admin/view/lang.html
+++ b/skel/admin/view/lang.html
@@ -1,5 +1,5 @@
 {% extends "view/layouts/admin.html" %}
-{% block title %}{% trans "International Command Center" %}{% endblock %}
+{% block title %}International Command Center{% endblock %}
 
 {% block left_submenu %}
 	{% include "view/shared/_lang_left_submenu.html" with index="true" %}
@@ -44,12 +44,25 @@
 </script>
 {% endblock %}
 {% block body %}
-<h1>{% trans "International Command Center" %}</h1>
+
+<h1>International Command Center</h1>
+
+{% if this_lang %}
+<ul class="toc right">
+	<li class="heading1"><a href="#languages">Manage Languages</a></li>
+	<li class="heading2"><a href="#untranslated">Untranslated messages</a></li>
+	<li class="heading2"><a href="#translated">Translated messages</a></li>
+	<li class="heading2"><a href="#actions">Actions</a></li>
+</ul>
+{% endif %}
+
+<h2 id="manage_languages">Manage Languages</h2>
+
 <p>
 <form action="/admin/create_lang">
     <p>
 {% if languages %}
-{% trans "Your language files:" %}
+Your language files:
 {% for lang in languages %}
 {% ifequal lang this_lang %}
 <strong>{{ lang }}</strong>
@@ -65,12 +78,17 @@
 </p>
 </form>
 
+{% if this_lang %}
+<hr>
+<h2 id="untranslated">Untranslated messages</h2>
+{% endif %}
+
 {% if untranslated_messages %}
-<p><em>{{ untranslated_messages|length }} untranslated messages:</em> (<a href="#" onclick="javascript:startTranslations()">{% trans "Fill in the blanks with Google!" %}</a> <span style="font-size: 11px; font-family: Courier New; font-weight: bold;">{% trans "EXPERIMENTAL FEATURE" %}</span>)</p>
+<p><em>{{ untranslated_messages|length }} untranslated messages:</em> (<a href="#" onclick="javascript:startTranslations()">Fill in the blanks with Google!</a> <span style="font-size: 11px; font-family: Courier New; font-weight: bold;">EXPERIMENTAL FEATURE</span>)</p>
 <form method="post">
 <table class="list files">
     <thead>
-        <tr><th>{% trans "Original" %}/{% trans "Translation" %}</th></tr>
+        <tr><th>Original/Translation</th></tr>
     </thead>
     <tbody>
         {% for message in untranslated_messages %}
@@ -98,38 +116,56 @@
 <div class="box">
 	<div id="issue_descr_fields">
 	<p>
-		<label for="issue_tracker_id">{% trans "Submit only translations filled in this form" %}</label>
-		<input type="submit" name="trans_only_filled" value="{% trans "Submit" %}">
+		<label for="issue_tracker_id">Submit only translations filled in this form</label>
+		<input type="submit" name="trans_only_filled" value="Submit">
 	</p>
 	</div>
 	<div id="issue_descr_fields">
 	<p>
-		<label for="issue_tracker_id">{% trans "Submit all translatable string to the po file (you can translate later with a translation tool like Poedit)" %}</label>
-		<input type="submit" name="trans_all_with_blanks" value="{% trans "Submit" %}">
+		<label for="issue_tracker_id">Submit all translatable string to the po file (you can translate later with a translation tool like Poedit)</label>
+		<input type="submit" name="trans_all_with_blanks" value="Submit">
 	</p>
 	</div>	
 </div>
 </form>
+{% else %}
+	{% if this_lang %}
+	<h3>No untranslated string messages found</h3>
+	{% endif %}
+{% endif %}
+
+{% if this_lang %}
+<hr>
+<h2 id="translated">Translated messages</h2>
 {% endif %}
 
 {% if translated_messages %}
 <p><em>{{ translated_messages|length }} translated messages:</em></p>
-<table border="1">
+<table class="list files">
     <thead>
-        <tr><th>{% trans "Original" %}</th><th>{% trans "Translation" %}</th></tr>
+        <tr><th>Original</th><th>Translation</th></tr>
     </thead>
     <tbody>
 {% for orig, msg in translated_messages %}
-<tr><td>{{ orig }}</td><td><em>{{ msg }}</em></td></tr>
+	<tr class="{% cycle 'odd' 'even' %}">
+		<td>{{ orig }}</td><td><em>{{ msg }}</em></td>
+	</tr>
 {% endfor %}
 </tbody>
 </table>
 {% if last_modified %}
-<p><em>{% trans "Last modified" %}: {{ last_modified|date:"N j, Y, P" }}</em></p>
+<p><em>Last modified: {{ last_modified|date:"N j, Y, P" }}</em></p>
 {% endif %}
+{% else %}
+	{% if this_lang %}
+	<h3>No translated string messages found</h3>
+	{% endif %}
 {% endif %}
+
 {% if this_lang %}
-<p><a href="/admin/delete_lang/{{ this_lang }}">{% trans "Delete this language file" %}...</a></p>
+<hr>
+<h2 id="actions">Actions</h2>
+<p><a href="/admin/delete_lang/{{ this_lang }}">Delete this language file...</a></p>
 {% endif %}
 
 {% endblock %}

--- a/skel/admin/view/layouts/admin.html
+++ b/skel/admin/view/layouts/admin.html
@@ -42,13 +42,13 @@
 			</div>
 	
 			<div id="ajax-indicator" style="display:none;">
-				<span>{% trans "Loading" %}...</span>
+				<span>Loading...</span>
 			</div>
 			
 			<div id="footer">
 			  <div class="bgl">
 			  	<div class="bgr">
-			    	{% trans "Powered by" %} <a href="http://www.chicagoboss.org">Chicago Boss</a>
+			    	Powered by <a href="http://www.chicagoboss.org">Chicago Boss</a>
 			  	</div>
 			  </div>
 			</div>

--- a/skel/admin/view/layouts/shared/_main_menu.html
+++ b/skel/admin/view/layouts/shared/_main_menu.html
@@ -1,7 +1,7 @@
 <ul>
-	<li><a class="index{% if index_section %} selected{% endif %}" href="{{ _base_url }}/admin">{% trans "Index" %}</a></li>
-	<li><a class="routes{% if routes_section %} selected{% endif %}" href="{{ _base_url }}/admin/routes">{% trans "Routes" %}</a></li>
-	<li><a class="model{% if model_section %} selected{% endif %}" href="{{ _base_url }}/admin/model">{% trans "Models" %}</a></li>
-	<li><a class="lang{% if lang_section %} selected{% endif %}" href="{{ _base_url }}/admin/lang">{% trans "Lang Center" %}</a></li>
-	<li><a class="upgrade{% if upgrade_section %} selected{% endif %}" href="{{ _base_url }}/admin/upgrade">{% trans "Code Upgrade" %}</a></li>
+	<li><a class="index{% if index_section %} selected{% endif %}" href="{{ _base_url }}/admin">Index</a></li>
+	<li><a class="routes{% if routes_section %} selected{% endif %}" href="{{ _base_url }}/admin/routes">Routes</a></li>
+	<li><a class="model{% if model_section %} selected{% endif %}" href="{{ _base_url }}/admin/model">Models</a></li>
+	<li><a class="lang{% if lang_section %} selected{% endif %}" href="{{ _base_url }}/admin/lang">Lang Center</a></li>
+	<li><a class="upgrade{% if upgrade_section %} selected{% endif %}" href="{{ _base_url }}/admin/upgrade">Code Upgrade</a></li>
 </ul>

--- a/skel/admin/view/model.html
+++ b/skel/admin/view/model.html
@@ -1,8 +1,8 @@
 {% extends "view/layouts/admin.html" %}
-{% block title %}{% trans "Models data management" %}{% endblock %}
+{% block title %}Models data management{% endblock %}
 
 {% block body %}
-<h1>{% trans "Models data management" %}</h1>
+<h1>Models data management</h1>
         <p>
         {% for model in models %}
         {% ifequal model this_model %}
@@ -19,7 +19,7 @@
         <p>
         <form name="new" action="/admin/create/{{ this_model }}">
             <input type="submit" value="+ New {{ this_model }}" />
-            &nbsp; &nbsp; {% trans "See also" %}: <a href="/doc/{{ this_model }}">Documentation for the <code>{{ this_model }}</code> model</a>
+            &nbsp; &nbsp; See also: <a href="/doc/{{ this_model }}">Documentation for the <code>{{ this_model }}</code> model</a>
         </form>
         </p>
         {% endif %}

--- a/skel/admin/view/routes.html
+++ b/skel/admin/view/routes.html
@@ -1,28 +1,28 @@
 {% extends "view/layouts/admin.html" %}
-{% block title %}{% trans "Loaded Routes" %}{% endblock %}
+{% block title %}Loaded Routes{% endblock %}
 
 {% block left_submenu %}
 <ul>
-	<li><a href="{{ _base_url }}/admin/routes/reload">{% trans "Reload routes" %}</a></li>
+	<li><a href="{{ _base_url }}/admin/routes/reload">Reload routes</a></li>
 </ul>
 {% endblock %}
 
 {% block right_submenu %}
 <ul>
-	<li><a href="http://chicagoboss.org/embedded/chicagoboss/api-controller.html">{% trans "API Doc" %}</a></li>
+	<li><a href="http://chicagoboss.org/embedded/chicagoboss/api-controller.html">API Doc</a></li>
 </ul>
 {% endblock %}
 
 {% block body %}
-<h1>{% trans "Loaded Routes: file boss.routes" %}</h1>
+<h1>Loaded Routes: file boss.routes</h1>
 
 <table class="list files">
 	<thead>
 		<tr>
-			<th>{% trans "Url/Special" %}</th>
-			<th>{% trans "Controller" %}</th>
-			<th>{% trans "Action" %}</th>
-			<th>{% trans "Params" %}</th>
+			<th>Url/Special</th>
+			<th>Controller</th>
+			<th>Action</th>
+			<th>Params</th>
 		</tr>
 	</thead>
 	<tbody>

--- a/skel/admin/view/shared/_lang_left_submenu.html
+++ b/skel/admin/view/shared/_lang_left_submenu.html
@@ -1,5 +1,5 @@
 <ul>
-	<li>{% if index %}* {% endif %}<a href="{{ _base_url }}/admin/lang">{% trans "Language list" %}</a></li>
-	<li>{% if automatic_translator %}* {% endif %}<a href="{{ _base_url }}/admin/big_red_button">{% trans "Automatic Translator" %}</a></li>
-	<li>{% if new_language %}* {% endif %}<a href="{{ _base_url }}/admin/create_lang">{% trans "New language file" %}</a></li>
+	<li>{% if index %}* {% endif %}<a href="{{ _base_url }}/admin/lang">Language list</a></li>
+	<li>{% if automatic_translator %}* {% endif %}<a href="{{ _base_url }}/admin/big_red_button">Automatic Translator</a></li>
+	<li>{% if new_language %}* {% endif %}<a href="{{ _base_url }}/admin/create_lang">New language file</a></li>
 </ul>

--- a/skel/admin/view/shared/_lang_right_submenu.html
+++ b/skel/admin/view/shared/_lang_right_submenu.html
@@ -1,3 +1,3 @@
 <ul>
-	<li><a href="http://chicagoboss.org/projects/chicagoboss/wiki/I18n_Quickstart">{% trans "I18n Quickstart" %}</a></li>
+	<li><a href="http://chicagoboss.org/projects/chicagoboss/wiki/I18n_Quickstart">I18n Quickstart</a></li>
 </ul>

--- a/skel/admin/view/upgrade.html
+++ b/skel/admin/view/upgrade.html
@@ -1,14 +1,14 @@
 {% extends "view/layouts/admin.html" %}
-{% block title %}{% trans "Chicago Boss Hot Code Upgrade" %}{% endblock %}
+{% block title %}Chicago Boss Hot Code Upgrade{% endblock %}
 
 {% block body %}
-<h1>{% trans "Chicago Boss Hot Code Upgrade" %}</h1>
+<h1>Chicago Boss Hot Code Upgrade</h1>
 <form method="post" action="{{ _base_url }}/admin/upgrade" class="tabular">
 <div class="box">
 	<div id="issue_descr_fields">
 	<p>
-		<label for="issue_tracker_id">{% trans "Upgrade BEAM code" %}</label>
-		<input type="submit" value="{% trans "Now" %}" />
+		<label for="issue_tracker_id">Upgrade BEAM code</label>
+		<input type="submit" value="Now" />
 	</p>
 	</div>
 </div>
@@ -18,8 +18,8 @@
 <div class="box">
 	<div id="issue_descr_fields">
 	<p>
-		<label for="issue_tracker_id">{% trans "Reload news.erl" %}</label>
-		<input type="submit" value="{% trans "Now" %}" />
+		<label for="issue_tracker_id">Reload news.erl</label>
+		<input type="submit" value="Now" />
 	</p>
 	</div>
 </div>

--- a/src/erlydtl/i18n/blocktrans_parser.erl
+++ b/src/erlydtl/i18n/blocktrans_parser.erl
@@ -6,8 +6,15 @@ parse(Tokens) ->
     parse(Tokens, []).
 
 parse([], Acc) ->
-    lists:reverse(Acc);
+    clean_crs(lists:reverse(Acc));
 parse([{open_blocktrans, _, Name}, {text, _, Text}, {close_blocktrans, _}|Rest], Acc) ->
     parse(Rest, [{Name, unicode:characters_to_binary(Text)}|Acc]);
 parse([{text, _, _}|Rest], Acc) ->
     parse(Rest, Acc).
+
+% internal functions
+
+clean_crs(Tokens) ->
+	lists:map(fun(X) -> 
+			{element(1, X), list_to_binary(string:strip(binary_to_list(element(2, X)), both, $\n))} 
+		end, Tokens).


### PR DESCRIPTION
- Fixed multiline with empty \n
- Get rid of extra \n's (start, end) :
  Now
  {% blocktrans foo %}
  hello
  {% endblocktrans %}
  is equal to {% blocktrans foo %}hello{% endblocktrans %}
- Removed trans of admin interface, this strings are mixed with application real strings, and never will be translated until we find a way to separate the (app and the admin translations)
