### PR TITLE
Update mail controller templates who otherwise crashes app

### DIFF
--- a/skel.template
+++ b/skel.template
@@ -20,8 +20,8 @@
 {template, "skel/Makefile", "{{dest}}/Makefile"}.
 {template, "skel/project.app.src", "{{dest}}/{{appid}}.app.src"}.
 {template, "skel/boss.config", "{{dest}}/boss.config"}.
-{file, "skel/src/mail/outgoing_mail_controller.erl", "{{dest}}/src/mail/{{appid}}_outgoing_mail_controller.erl"}.
-{file, "skel/src/mail/incoming_mail_controller.erl", "{{dest}}/src/mail/{{appid}}_incoming_mail_controller.erl"}.
+{template, "skel/src/mail/outgoing_mail_controller.erl", "{{dest}}/src/mail/{{appid}}_outgoing_mail_controller.erl"}.
+{template, "skel/src/mail/incoming_mail_controller.erl", "{{dest}}/src/mail/{{appid}}_incoming_mail_controller.erl"}.
 {file, "skel/priv/static/chicago-boss.png", "{{dest}}/priv/static/chicago-boss.png"}.
 {file, "skel/priv/static/favicon.ico", "{{dest}}/priv/static/favicon.ico"}.
 {file, "skel/priv/boss.routes", "{{dest}}/priv/{{appid}}.routes"}.

--- a/skel/src/mail/incoming_mail_controller.erl
+++ b/skel/src/mail/incoming_mail_controller.erl
@@ -1,4 +1,4 @@
--module(incoming_mail_controller).
+-module({{appid}}_incoming_mail_controller).
 -compile(export_all).
 
 authorize_(User, DomainName, IPAddress) ->

--- a/skel/src/mail/outgoing_mail_controller.erl
+++ b/skel/src/mail/outgoing_mail_controller.erl
@@ -1,4 +1,4 @@
--module(outgoing_mail_controller).
+-module({{appid}}_outgoing_mail_controller).
 -compile(export_all).
 
 %% See http://www.chicagoboss.org/api-mail-controller.html for what should go in here


### PR DESCRIPTION
The mail controller templates module name missed the application id, causing them to crash when trying to send mail in a clean project.
