### PR TITLE
render_other in mailing controllers

### DIFF
--- a/src/boss/boss_mail.erl
+++ b/src/boss/boss_mail.erl
@@ -11,12 +11,12 @@ send_template(Application, Action, Args) ->
     boss_load:load_mail_controllers(),
     Controller = list_to_atom(lists:concat([Application, "_outgoing_mail_controller"])),
     case apply(Controller, Action, Args) of
-        {ok, FromAddress, ToAddress, HeaderFields} ->
-            send_message(Application, FromAddress, ToAddress, Action, HeaderFields, [], []);
-        {ok, FromAddress, ToAddress, HeaderFields, Variables} -> 
-            send_message(Application, FromAddress, ToAddress, Action, HeaderFields, Variables, []);
-        {ok, FromAddress, ToAddress, HeaderFields, Variables, Attachments} -> 
-            send_message(Application, FromAddress, ToAddress, Action, HeaderFields, Variables, Attachments);
+        {MailAction, FromAddress, ToAddress, HeaderFields} ->
+            send_message(Application, FromAddress, ToAddress, Action, HeaderFields, [], [], MailAction);
+        {MailAction, FromAddress, ToAddress, HeaderFields, Variables} -> 
+            send_message(Application, FromAddress, ToAddress, Action, HeaderFields, Variables, [], MailAction);
+        {MailAction, FromAddress, ToAddress, HeaderFields, Variables, Attachments} -> 
+            send_message(Application, FromAddress, ToAddress, Action, HeaderFields, Variables, Attachments, MailAction);
         nevermind ->
             ok
     end.
@@ -31,13 +31,13 @@ send(FromAddress, ToAddress, Subject, Body) ->
             {"From", FromAddress}], "text/plain"), 
     gen_server:call(boss_mail, {deliver, FromAddress, ToAddress, fun() -> [MessageHeader, "\r\n", Body] end}).
 
-send_message(App, FromAddress, ToAddress, Action, HeaderFields, Variables, Attachments) ->
-    BodyFun = fun() -> build_message(App, Action, HeaderFields, Variables, Attachments) end,
+send_message(App, FromAddress, ToAddress, Action, HeaderFields, Variables, Attachments, MailAction) ->
+    BodyFun = fun() -> build_message(App, Action, HeaderFields, Variables, Attachments, MailAction) end,
     gen_server:call(boss_mail, {deliver, FromAddress, ToAddress, BodyFun}).
 
-build_message(App, Action, HeaderFields, Variables, Attachments) ->
+build_message(App, Action, HeaderFields, Variables, Attachments, MailAction) ->
     ContentLanguage = proplists:get_value("Content-Language", HeaderFields),
-    {MimeType, MessageBody} = build_message_body_attachments(App, Action, Variables, Attachments, ContentLanguage),
+    {MimeType, MessageBody} = build_message_body_attachments(App, Action, Variables, Attachments, ContentLanguage, MailAction),
     MessageHeader = build_message_header(HeaderFields, MimeType),
     [MessageHeader, "\r\n", MessageBody].
 
@@ -64,17 +64,23 @@ add_fields([Field|Rest], HeaderFields, Acc) ->
             add_fields(Rest, HeaderFields, [Field, ": ", Value, "\r\n" | Acc])
     end.
 
-build_message_body_attachments(App, Action, Variables, [], ContentLanguage) ->
-    build_message_body(App, Action, Variables, ContentLanguage);
-build_message_body_attachments(App, Action, Variables, Attachments, ContentLanguage) ->
+build_message_body_attachments(App, Action, Variables, [], ContentLanguage, MailAction) ->
+    build_message_body(App, Action, Variables, ContentLanguage, MailAction);
+build_message_body_attachments(App, Action, Variables, Attachments, ContentLanguage, MailAction) ->
     Boundary = smtp_util:generate_message_boundary(),
-    {MimeType, MessageBody} = build_message_body(App, Action, Variables, ContentLanguage),
+    {MimeType, MessageBody} = build_message_body(App, Action, Variables, ContentLanguage, MailAction),
     {"multipart/mixed; boundary=\""++Boundary++"\"",
         render_multipart_view([{MimeType, MessageBody}|Attachments], Boundary)}.
 
-build_message_body(App, Action, Variables, ContentLanguage) ->
-    HtmlResult = render_view(App, {Action, "html"}, Variables, ContentLanguage),
-    TextResult = render_view(App, {Action, "txt"}, Variables, ContentLanguage),
+build_message_body(App, Action, Variables, ContentLanguage, MailAction) ->
+	case MailAction of
+		ok ->
+    			HtmlResult = render_view(App, {Action, "html"}, Variables, ContentLanguage),
+    			TextResult = render_view(App, {Action, "txt"}, Variables, ContentLanguage);
+    		{render_other, TemplName} ->
+    			HtmlResult = render_view(App, {TemplName, "html"}, Variables, ContentLanguage),
+    			TextResult = render_view(App, {TemplName, "txt"}, Variables, ContentLanguage)
+    	end,
     case HtmlResult of
         undefined ->
             case TextResult of


### PR DESCRIPTION
Added 'MailAction' for mailing controllers, which allows to use 'render_other' keyword to send e-mail template with filename different than called function. Returning 'ok' instead of 'render_other' works the same as before this patch.
