### PR TITLE
Added jsonp response type

### DIFF
--- a/doc-src/api-controller.html
+++ b/doc-src/api-controller.html
@@ -180,6 +180,18 @@ before_(_) -&gt;<br />
 <p>Return <code>Data</code> to the client as a JSON object while setting additional HTTP <code>Headers</code>.</p>
 
 <div class="code spec">
+    {jsonp, Callback<span class="typevar">::string()</span>, Data<span class="typevar">::proplist()</span>}
+</div>
+
+<p>Returns <code>Data</code> as a JSONP method call to the client. Performs appropriate serialization if the values in Data contain a BossRecord or a list of BossRecords.</p>
+
+<div class="code spec">
+    {jsonp, Callback<span class="typevar">::string()</span>, Data<span class="typevar">::proplist()</span>, Headers<span class="typevar">::proplist()</span>}
+</div>
+
+<p>Return <code>Data</code> to the client as a JSONP method call (as above) while setting additional HTTP <code>Headers</code>.</p>
+
+<div class="code spec">
     not_found
 </div>
 

--- a/src/boss/boss_web_controller.erl
+++ b/src/boss/boss_web_controller.erl
@@ -581,6 +581,14 @@ process_action_result(Info, {json, Data, Headers}, AppInfo, AuthInfo) ->
             [{"Content-Type", proplists:get_value("Content-Type", Headers, "application/json")}
                 |proplists:delete("Content-Type", Headers)]}, AppInfo, AuthInfo);
 
+process_action_result(Info, {jsonp, Callback, Data}, AppInfo, AuthInfo) ->
+    process_action_result(Info, {jsonp, Callback, Data, []}, AppInfo, AuthInfo);
+process_action_result(Info, {jsonp, Callback, Data, Headers}, AppInfo, AuthInfo) ->
+    JsonData  = boss_json:encode(Data, AppInfo#boss_app_info.model_modules),
+    process_action_result(Info, {output, Callback ++ "(" ++ JsonData ++ ");",
+            [{"Content-Type", proplists:get_value("Content-Type", Headers, "application/javascript")}
+                |proplists:delete("Content-Type", Headers)]}, AppInfo, AuthInfo);
+
 process_action_result(Info, {output, Payload}, AppInfo, AuthInfo) ->
     process_action_result(Info, {output, Payload, []}, AppInfo, AuthInfo);
 process_action_result(_, {output, Payload, Headers}, _, _) ->


### PR DESCRIPTION
Handler for {jsonp, _}

e.g. {jsonp, "thing", [{stuff, "Things."}]} will render as:

thing({"stuff":"Things."});

(as application/javascript)
