### PR TITLE
Update queries with undefined values (sql drivers)

### DIFF
--- a/src/boss/db_adapters/boss_db_adapter_mysql.erl
+++ b/src/boss/db_adapters/boss_db_adapter_mysql.erl
@@ -254,6 +254,7 @@ build_update_query(Record) ->
     {_, TableName, Id} = infer_type_from_id(Record:id()),
     Updates = lists:foldl(fun
             ({id, _}, Acc) -> Acc;
+            ({_, undefined}, Acc) -> Acc;
             ({A, V}, Acc) -> 
                 AString = atom_to_list(A),
                 Value = case lists:suffix("_id", AString) of

--- a/src/boss/db_adapters/boss_db_adapter_pgsql.erl
+++ b/src/boss/db_adapters/boss_db_adapter_pgsql.erl
@@ -219,6 +219,7 @@ build_update_query(Record) ->
     {_, TableName, Id} = infer_type_from_id(Record:id()),
     Updates = lists:foldl(fun
             ({id, _}, Acc) -> Acc;
+            ({_, undefined}, Acc) -> Acc;
             ({A, V}, Acc) -> 
                 AString = atom_to_list(A),
                 Value = case lists:suffix("_id", AString) of


### PR DESCRIPTION
...nfer_type_from_id was called for undefined values (this was correctly managed for build_insert_query)
