### PR TITLE
Add missing application argument

### DIFF
--- a/src/boss/boss_load.erl
+++ b/src/boss/boss_load.erl
@@ -186,7 +186,7 @@ compile_view_erlydtl(Application, ViewPath, OutDir, TranslatorPid) ->
                             undefined -> default;
                             Body -> list_to_binary(Body)
                         end
-                end}, {blocktrans_locales, boss_files:language_list()}]),
+                end}, {blocktrans_locales, boss_files:language_list(Application)}]),
     case Res of
         ok -> {ok, Module};
         Err -> Err


### PR DESCRIPTION
Re-compiling templates gives the following error:

```
=ERROR REPORT==== 5-Feb-2012::13:59:23 ===
{undef,[{boss_files,language_list,[],[]},
        {boss_load,compile_view_erlydtl,4,
                   [{file,"src/boss/boss_load.erl"},{line,189}]},
        {boss_load,load_view_if_dev,3,
                   [{file,"src/boss/boss_load.erl"},{line,258}]},
        {boss_web_controller,render_view,6,
                             [{file,"src/boss/boss_web_controller.erl"},
                              {line,643}]},
        {boss_web_controller,execute_action,5,
                             [{file,"src/boss/boss_web_controller.erl"},
                              {line,545}]},
        {boss_web_controller,process_request,5,
                             [{file,"src/boss/boss_web_controller.erl"},
                              {line,389}]},
        {timer,tc,3,[{file,"timer.erl"},{line,194}]},
        {boss_web_controller,handle_request,3,
                             [{file,"src/boss/boss_web_controller.erl"},
                              {line,312}]}]}
```

This is fixed by adding the missing `Application` argument to `boss_files:language_list/1`.
