### PR TITLE
My solution for issue #75

### DIFF
--- a/doc-src/api-config.html
+++ b/doc-src/api-config.html
@@ -2,6 +2,7 @@
 {% block api_content %}
 <p>All configuration takes place in <code>boss.config</code> in your project directory. Valid configuration options are:</p>
 <ul>
+    <li><code>additional_supervisors</code> - A list of modules which implement the OTP-Supervisor (<code>gen_sup</code>) behaviour. These supervisors will be started in Boss' supervision tree and can be used to implement complex backend behaviour.</li>
     <li><code>assume_locale</code> - The presumed locale of translatable strings. Defaults to "en".</li>
     <li><code>cache_adapter</code> - The cache adapter to use. Currently the only valid value is <code>memcached_bin</code>.</li>
     <li><code>cache_servers</code> - A list of cache servers (<code>{Host, Port, PoolSize}</code>). Defaults to <code>[{"localhost", 11211, 1}]</code>.

--- a/src/boss/boss_sup.erl
+++ b/src/boss/boss_sup.erl
@@ -48,5 +48,14 @@ init([]) ->
 	   {boss_web_controller, start_link, [WebConfig]},
 	   permanent, 5000, worker, dynamic},
 
-    Processes = [Web],
+    % add additional supervisors to the supervision tree
+    AddSups = boss_env:get_env(additional_supervisors, []),
+
+    Processes = lists:foldl(fun(App, Acc) ->
+                                    [{App,
+                                      {App, start_link, []},
+                                      permanent, 5000, worker, []}
+                                     |Acc]
+                            end, [Web], AddSups),
+
     {ok, {{one_for_one, 10, 10}, Processes}}.


### PR DESCRIPTION
Adds a new configuration option `additional_supervisors` with a list of
modules which implement the `gen_fsm` behaviour. These supervisors will
be started in boss' supervision tree. It can be used to include complex
backend functionality directly in the boss application and start it all
together.
