### PR TITLE
Init only when running in base directory

### DIFF
--- a/skel/priv/rebar/boss_plugin.erl
+++ b/skel/priv/rebar/boss_plugin.erl
@@ -95,9 +95,9 @@ init(_RebarConf, AppFile) ->
 %% @end
 %%--------------------------------------------------------------------
 pre_compile(RebarConf, AppFile) ->
-	{ok, BossConf} = init(RebarConf, AppFile),
 	case is_base_dir() of
 		true -> 
+			{ok, BossConf} = init(RebarConf, AppFile),
 			boss_rebar:run(compile, RebarConf, BossConf, AppFile),
 			halt(0);
 		false -> ok
@@ -113,9 +113,9 @@ pre_compile(RebarConf, AppFile) ->
 %% @end
 %%--------------------------------------------------------------------
 pre_eunit(RebarConf, AppFile) ->
-	{ok, BossConf} = init(RebarConf, AppFile),
 	case is_base_dir() of
 		true -> 
+			{ok, BossConf} = init(RebarConf, AppFile),
 			boss_rebar:run(test_eunit, RebarConf, BossConf, AppFile),
 			halt(0);
 		false -> ok


### PR DESCRIPTION
Recently I've been trying deploy CB app on heroku. As far as I noticed, rebar fires up every matching hook from all modules (plugins). Here's sample stacktrace:

```
[{boss_plugin,boss_config,0},
  {boss_plugin,boss_config_value,2},
  {boss_plugin,init,2},
  {boss_plugin,pre_compile,2},
  {rebar_core,run_modules,4},
  {rebar_core,execute,4},
  {rebar_core,process_dir0,6},
  {rebar_core,process_each,5}]}}
```

When rebar executes `boss_plugin:pre_compile` inside e.g. `deps/aleppo` directory, then it can't find `boss.config` because this is not base directory.
