### PR TITLE
Unnecessary directory name dependency

### DIFF
--- a/skel/boss.config
+++ b/skel/boss.config
@@ -13,7 +13,7 @@
     {session_exp_time, 525600}
 ]},
 { {{appid}}, [
-    {path, "../{{appid}}"},
+    {path, "."},
     {base_url, "/"}
 ]}
 ].


### PR DESCRIPTION
Current directory is what we want. We don't need to go up and down in directory hierarchy. I think that it's really unnecessary directory name dependency.
