### PR TITLE
Improved rebar compile and testing

### DIFF
--- a/priv/rebar/boss_rebar_eunit.erl
+++ b/priv/rebar/boss_rebar_eunit.erl
@@ -136,6 +136,7 @@ eunit(RebarConf, BossConf, AppFile) ->
 	%% boss_change
 	%% Load all boss ebin dir and start boss
 	boss_rebar:boss_load(BossConf, AppFile),
+    boss_rebar:init_conf_test(BossConf),
 	boss_rebar:boss_start(BossConf),
 
     %% Build a list of all the .beams in ?EUNIT_DIR -- use this for

--- a/src/boss/boss_web_test.erl
+++ b/src/boss/boss_web_test.erl
@@ -18,7 +18,7 @@ bootstrap_test_env(Application, Adapter) ->
                     _ -> Acc
                 end
         end, [], [db_port, db_host, db_username, db_password, db_database]),
-    ok = application:start(Application),
+    %ok = application:start(Application),
     {ok, RouterSupPid} = boss_router:start([{application, Application}, 
             {controllers, boss_files:web_controller_list(Application)}]),
     boss_db:start([{adapter, Adapter}|DBOptions]),


### PR DESCRIPTION
- The load checks if modules are allready loaded (no more warnings)
- The Boss start now waits to all applications initialize (now eunit/functional tests can be performed with a full powered boss env)
- Before compilation, boss.config config is injected (before, some config params used in compilation time was missing)
- For tests tasks (eunit/functional), the rebar plugin check if a boss.test.config exists, if not exists loads the default boss.config. With this you can separate the dev/tests databases for fixture creation/maintenance
