### PR TITLE
Allow http port to be configurable by env var specified in boss.config

### DIFF
--- a/doc-src/api-config.html
+++ b/doc-src/api-config.html
@@ -33,7 +33,7 @@
     <li><code>mail_relay_username</code> - The username used for connecting to the SMTP relay (if needed).</li>
     <li><code>mail_relay_password</code> - The password used for connecting to the SMTP relay (if needed).</li>
     <li><code>master_node</code> - For distributed configurations, the name of the master node. The master node runs global services (incoming mail, message queue, events, sessions). Should be an atom, e.g. <code>somenode@somehost</code>. The node name is specified in the <code>-sname</code> or <code>-name</code> argument in the startup script.</li>
-    <li><code>port</code> - The port to run the HTTP server on. Defaults to 8001.</li>
+    <li><code>port</code> - The port to run the HTTP server on, or a tuple of the format {env, "PORTVAR"} (where PORTVAR is the name of an environment variable containing the port number). Defaults to 8001.</li>
     <li><code>server</code> - The HTTP server to use. Valid values are:
     <ul>
         <li><code>mochiweb</code> - The <a href="http://code.google.com/p/mochiweb/">Mochiweb</a> Web Server</li>

--- a/src/boss/boss_sup.erl
+++ b/src/boss/boss_sup.erl
@@ -41,8 +41,16 @@ upgrade() ->
 %% @spec init([]) -> SupervisorTree
 %% @doc supervisor callback.
 init([]) ->
-    Ip = case os:getenv("MOCHIWEB_IP") of false -> "0.0.0.0"; Any -> Any end,   
-    Port = case application:get_env(port) of {ok, P} -> P; undefined -> 8001 end,
+    Ip = case os:getenv("MOCHIWEB_IP") of false -> "0.0.0.0"; Any -> Any end,
+    Port = case application:get_env(port) of
+        {ok, {env, PortVar}} ->
+            case os:getenv(PortVar) of
+                false -> 8001;
+                PortStr -> list_to_integer(PortStr)
+            end;
+        {ok, P} when is_integer(P) -> P;
+        undefined -> 8001
+    end,
     WebConfig = [ {ip, Ip}, {port, Port} ],
     Web = {boss_web_controller,
 	   {boss_web_controller, start_link, [WebConfig]},


### PR DESCRIPTION
Recently got CB running on heroku (will write up something in the wiki).

Required being able to set the port number from an environment variable.  How's this look?
