### PR TITLE
ChicagoBoss does not honor {vsn, git} in .app.src

### DIFF
--- a/src/boss/boss_load.erl
+++ b/src/boss/boss_load.erl
@@ -44,7 +44,9 @@ load_all_modules_and_emit_app_file(AppName, OutDir) ->
     Vsn = proplists:get_value(vsn, AppData1, []),
     ComputedVsn = case vcs_vsn_cmd(Vsn) of
         {unknown, Val} -> Val;
-        Cmd -> os:cmd(Cmd)
+        Cmd ->
+            VsnString = os:cmd(Cmd),
+            string:strip(VsnString, right, $\n)
     end,
     AppData2 = lists:keyreplace(vsn, 1, AppData1, {vsn, ComputedVsn}),
     DefaultEnv = proplists:get_value(env, AppData2, []),


### PR DESCRIPTION
When building rebar apps you can use {vsn, git} in your .app.src for generating a vsn based on git commit. Chicago Boss does not honor this and instead generates an invalid .app file.

This patch enables that.
