### PR TITLE
appilcation don't start if vm_cookie not set

### DIFF
--- a/priv/rebar/boss_rebar.erl
+++ b/priv/rebar/boss_rebar.erl
@@ -393,7 +393,7 @@ sname(BossConf, AppFile) ->
 
 cookie_option(BossConf) ->
     case boss_config_value(BossConf, boss, vm_cookie) of
-        undefined ->
+        {error, _} ->
             "";
         Cookie ->
             "-setcookie "++Cookie


### PR DESCRIPTION
appilcation don't start if vm_cookie not set
just a small fix on the last release
