### PR TITLE
Remove -compile(export_all) from BossNews

### DIFF
--- a/src/bmq/bmq.erl
+++ b/src/bmq/bmq.erl
@@ -1,6 +1,6 @@
 -module(bmq).
 
--export([now/1, poll/2, pull/3, push/2].
+-export([now/1, poll/2, pull/3, push/2]).
 
 pull(Channel, Timestamp, Subscriber) ->
     gen_server:call(bmq, {pull, Channel, Timestamp, Subscriber}).


### PR DESCRIPTION
Changed `-compile(export_all)` to an alphabetical list within the `-export([])` directive.
