### PR TITLE
Added more information to skel/boss.config

### DIFF
--- a/skel/boss.config
+++ b/skel/boss.config
@@ -1,18 +1,205 @@
+%% https://github.com/evanmiller/ChicagoBoss/wiki/Configuration 
+
+%% SYSTEM CONFIGURATIONS
+
+%% vm_cookie - Erlang cookie, must be the same for all nodes in the cluster. 
+%% nm_name - Node name to use in production. Must be unique for all nodes in the cluster. Defaults to <application_name>@<host_name>
+%% vm_max_processes -  The limit of processes that the VM is allowed to spawn. Defaults to 134217727 (the highest possible value).
+
 [{boss, [
     {path, "{{src}}"},
     {applications, [{{appid}}]},
+    {assume_locale, "en"},
+%    {vm_cookie, "secret"},
+%    {vm_name, "leader"},
+%    {vm_max_processes, 134217727},
+
+%%%%%%%%%%%
+%% Cache %%
+%%%%%%%%%%%
+
+%% cache_adapter - Which cache adapter to use. Currently the only valid value is memcached_bin. 
+%% cache_enable - Whether to enable the cache. Defaults to false.
+%% cache_servers - A list of cache servers ({Host, Port, PoolSize}). Defaults to [{"localhost", 11211, 1}].
+%% cache_exp_time- The maximum time to keep a cache entry, in seconds. Defaults to 60.
+
+%    {cache_adapter,"memcached_bin"},
+%    {cache_enable,false},
+%    {cache_servers,[{"localhost", 11211, 1}]},
+%    {cache_exp_time,60}, 
+
+%%%%%%%%%%%%%%
+%% Database %%
+%%%%%%%%%%%%%%
+
+%% db_host - The hostname of the database. Defaults to "localhost".
+%% db_port - The port of the database. Defaults to 1978.
+%% db_adapter - The database adapter to use. Valid values are: 
+%%     mock - In-memory (non-persistent) database, useful for testing
+%%     mnesia - Mnesia
+%%     mongodb- MongoDB
+%%     mysql - MySQL
+%%     pgsql - PostgreSQL
+%%     riak - Riak
+%%     tyrant - Tokyo Tyrant
+%% db_username - The username used for connecting to the database (if needed).
+%% db_password - The password used for connecting to the database (if needed).
+%% db_database - The name of the database to connect to (if needed).
+
     {db_host, "localhost"},
     {db_port, 1978},
     {db_adapter, mock},
+%    {db_username, "boss"},
+%    {db_password, "boss"},
+%    {db_database, "boss"},
+
+%%  MongoDB only
+%%
+%% Read https://github.com/TonyGen/mongodb-erlang#readme for details
+%% db_write_mode - defaults to safe
+%% db_read_mode - defaults to master
+%    {db_write_mode, safe},
+%    {db_read_mode, master},
+
+%% Database sharding
+%% A list of proplists with per-shard database configuration. 
+%% The proplists override the above options, and should contain two additional options: 
+%%  {db_shards, [ 
+%%      [ 
+%%          {db_host, "localhost"}, 
+%%          {db_adapter, mysql}, 
+%%          {db_port, 3306}, 
+%%          {db_username, "dbuser"}, 
+%%          {db_password, "dbpass"}, 
+%%          {db_database, "database"},
+%%          {db_shard_id, shard_id_atom}, 
+%%          {db_shard_models, [model_atom_1, model_atom_2, model_atom_3, etc]} 
+%%      ] 
+%%  ]},
+
+%%%%%%%%%%%%%
+%% Logging %%
+%%%%%%%%%%%%%
+
+%% Directory in which to keep log files. 
+%% Location is relative to the project directory. 
+%% Defaults to "log".
+
     {log_dir, "log"},
-    {server, mochiweb},
+
+%%%%%%%%%%
+%% Mail %%
+%%%%%%%%%%
+
+%% mail_driver - The email delivery driver to use. Valid values are:
+%%      boss_mail_driver_smtp - SMTP delivery. If mail_relay is present, 
+%%                              it is used as a relay, otherwise direct delivery is attempted.
+%%      boss_mail_driver_mock - A black hole, useful for testing.
+%% mail_relay_host - The relay server for SMTP mail deliveries.
+%% mail_relay_username -The username used for connecting to the SMTP relay (if needed).
+%% mail_relay_password -The password used for connecting to the SMTP relay (if needed).
+
+%    {mail_driver, "boss_mail_driver_mock"},
+%    {mail_relay_host, "smtp.example.com"},
+%    {mail_relay_username, "webmaster@example.com"},
+%    {mail_relay_password, "mailpassword"},
+
+
+%%%%%%%%%%%%%%%%%%
+%% MessageQueue %%
+%%%%%%%%%%%%%%%%%%
+
+
+%% master_node - 
+%%     For distributed configurations, the name of the master node. 
+%%     The master node runs global services (incoming mail, message queue, events, sessions). 
+%%     Should be an atom, e.g. somenode@somehost. 
+%%     The node name is specified in the -sname or -name argument in the startup script.
+%% mq_max_age- Maximum age of messages in the [message queue], in seconds. Defaults to 60.
+
+%    {master_node, master@example.com},
+%    {mq_max_age, 60},
+
+%%%%%%%%%%%%%%%
+%% Webserver %%
+%%%%%%%%%%%%%%%
+
+%% The port to run the server on. Defaults to 8001.
+%% The HTTP server to use. Valid values are: 
+%%     mochiweb - The Mochiweb Web Server
+%%     misultin - The Misultin Web Server (deprecated)
+%%     cowboy - The Cowboy Web Server (COMET, WebSockets (soon), highly scalable, ...)
     {port, 8001},
+    {server, mochiweb},
+
+
+%%%%%%%%%%%%%%
+%% Sessions %%
+%%%%%%%%%%%%%%
+
+%% Selects the session driver to use. Valid values:
+%%     cache - Store sessions in the configured cache servers. Requires cache_enable to be set to true.
+%%     ets (default)
+%%     mnesia
+
+%% session_enable - Whether to enable sessions. Defaults to true.
+%% session_key - Cookie key for sessions. Defaults to "_boss_session"
+%% session_exp_time - Expiration time for the session cookie. Defaults to 525600 
+%% session_mnesia_nodes, for {session_adapter, mnesia} only - List of Mnesia nodes, defaults to node()
+%% session_domain - (optional, sets the Domain=x cookie option), 
+%%     this can be used by ex: to enable subdomain apps 
+%%     (*.domain.com) with the param ".domain.com" => {session_domain, ".domain.com"}
+
     {session_adapter, mock},
     {session_key, "_boss_session"},
-    {session_exp_time, 525600}
+    {session_exp_time, 525600},
+%    {session_enable, true},
+%    {session_mnesia_nodes, [node()]},
+%    {session_domain, ".domain.com"},
+
+%%%%%%%%%%%%%%%
+%% Templates %%
+%%%%%%%%%%%%%%%
+
+%% template_tag_modules - List of external modules to search for custom ErlyDTL tags.
+%% template_filter_modules - List of external modules to search for custom ErlyDTL filters.
+    {template_tag_modules, []},
+    {template_filter_modules, []},
+
+%%%%%%%%%%%%%%%%%%%%%
+%% Incoming Emails %%
+%%%%%%%%%%%%%%%%%%%%%
+
+%% smtp_server_enable - Enable the SMTP server for incoming mail
+%% smtp_server_address - The address that the SMTP server should bind to. Defaults to {0, 0, 0, 0} (all interfaces).
+%% smtp_server_domain - The host name of the SMTP server
+%% smtp_server_port - The port that the SMTP server should listen on. Defaults to 25.
+
+%    {smtp_server_enable, ""},
+%    {smtp_server_address, {0, 0, 0, 0}},
+%    {smtp_server_domain, "smtp.example.com"},
+%    {smtp_server_port, 25},
+
+%% smtp_server_protocol - The protocol that the SMTP server should use. Valid values are:
+%%     tcp (default)
+%%     ssl
+%    {smtp_server_protocol, "tcp"},
+
+%%%%%%%%%
+%% SSL %%
+%%%%%%%%%
+
+%% Enable HTTP over SSL
+%    {ssl_enable, true},
+%% SSL options; see ssl(3erl)
+%    {ssl_options, []} 
+
 ]},
+
+%% APPLICATION CONFIGURATIONS
 { {{appid}}, [
     {path, "../{{appid}}"},
-    {base_url, "/"}
+    {base_url, "/"},
+%    {domains, ["all"]}
 ]}
 ].


### PR DESCRIPTION
This commit adds all configuration options to the skeleton
template as comments. This allows developers to build new
skeletons quickly for their own projects.

Note, I've changed quite a bit from the comment in #136, which appears
to have things like personal passwords and other diversions
from the defaults in there.
