### PR TITLE
Add include_dirs configuration option

### DIFF
--- a/doc-src/api-config.html
+++ b/doc-src/api-config.html
@@ -23,7 +23,7 @@
     <ul>
         <li><code>db_shard_models</code> - A list of models (atoms) which are stored on the shard.</li>
     </ul></li>
-    <li><code>include_dirs</code> - List of additonal directories to be searched for files specified in <code>-include</code> directives.</li>
+    <li><code>include_dirs</code> - List of additional directories to be searched for files specified in <code>-include</code> directives.</li>
     <li><code>log_dir</code> - Directory in which to keep log files. Location is relative to the project directory. Defaults to "log".</li>
     <li><code>mail_driver</code> - The email delivery driver to use. Valid values are:
     <ul>

--- a/doc-src/api-config.html
+++ b/doc-src/api-config.html
@@ -23,7 +23,7 @@
     <ul>
         <li><code>db_shard_models</code> - A list of models (atoms) which are stored on the shard.</li>
     </ul></li>
-	 <li><code>include_dirs</code> - List of additonal directories to be searched for files specified in <code>-include</code> directives.</li>
+    <li><code>include_dirs</code> - List of additonal directories to be searched for files specified in <code>-include</code> directives.</li>
     <li><code>log_dir</code> - Directory in which to keep log files. Location is relative to the project directory. Defaults to "log".</li>
     <li><code>mail_driver</code> - The email delivery driver to use. Valid values are:
     <ul>

--- a/doc-src/api-config.html
+++ b/doc-src/api-config.html
@@ -23,6 +23,7 @@
     <ul>
         <li><code>db_shard_models</code> - A list of models (atoms) which are stored on the shard.</li>
     </ul></li>
+	 <li><code>include_dirs</code> - List of additonal directories to be searched for files specified in <code>-include</code> directives.</li>
     <li><code>log_dir</code> - Directory in which to keep log files. Location is relative to the project directory. Defaults to "log".</li>
     <li><code>mail_driver</code> - The email delivery driver to use. Valid values are:
     <ul>

--- a/src/boss/boss_load.erl
+++ b/src/boss/boss_load.erl
@@ -227,13 +227,13 @@ compile_view_erlydtl(Application, ViewPath, OutDir, TranslatorPid) ->
     end.
 
 compile_model(ModulePath, OutDir) ->
-    boss_model_manager:compile(ModulePath, [{out_dir, OutDir}, {include_dirs, [boss_files:include_dir()]}]).
+    boss_model_manager:compile(ModulePath, [{out_dir, OutDir}, {include_dirs, [boss_files:include_dir() | boss_env:get_env(boss, include_dirs, [])]}]).
 
 compile_controller(ModulePath, OutDir) ->
-    boss_controller_compiler:compile(ModulePath, [{out_dir, OutDir}, {include_dirs, [boss_files:include_dir()]}]).
+    boss_controller_compiler:compile(ModulePath, [{out_dir, OutDir}, {include_dirs, [boss_files:include_dir() | boss_env:get_env(boss, include_dirs, [])]}]).
 
 compile(ModulePath, OutDir) ->
-    boss_compiler:compile(ModulePath, [{out_dir, OutDir}, {include_dirs, [boss_files:include_dir()]}]).
+    boss_compiler:compile(ModulePath, [{out_dir, OutDir}, {include_dirs, [boss_files:include_dir() | boss_env:get_env(boss, include_dirs, [])]}]).
 
 load_view_lib(Application, OutDir, TranslatorPid) ->
     {ok, HelperDirModule} = compile_view_dir_erlydtl(boss_files:view_html_tags_path(), 

--- a/src/boss/boss_web_controller.erl
+++ b/src/boss/boss_web_controller.erl
@@ -361,7 +361,7 @@ find_application_for_path(Host, Path, Default, [App|Rest], MatchScore) ->
 
 stop_init_scripts(Application, InitData) ->
     lists:foldr(fun(File, _) ->
-                case boss_compiler:compile(File, [{include_dirs, [boss_files:include_dir()]}]) of
+                case boss_compiler:compile(File, [{include_dirs, [boss_files:include_dir() | boss_env:get_env(boss, include_dirs, [])]}]) of
                     {ok, Module} ->
                         case proplists:get_value(Module, InitData, init_failed) of
                            init_failed ->
@@ -375,7 +375,7 @@ stop_init_scripts(Application, InitData) ->
 
 run_init_scripts(AppName) ->
     lists:foldl(fun(File, Acc) ->
-                case boss_compiler:compile(File, [{include_dirs, [boss_files:include_dir()]}]) of
+                case boss_compiler:compile(File, [{include_dirs, [boss_files:include_dir() | boss_env:get_env(boss, include_dirs, [])]}]) of
                     {ok, Module} ->
                         case catch Module:init() of
                             {ok, Info} ->

--- a/src/boss/boss_web_test.erl
+++ b/src/boss/boss_web_test.erl
@@ -25,7 +25,7 @@ bootstrap_test_env(Application, Adapter) ->
     boss_session:start(),
     boss_mq:start(),
     lists:map(fun(File) ->
-                {ok, _} = boss_compiler:compile(File, [{include_dirs, [boss_files:include_dir()]}])
+                {ok, _} = boss_compiler:compile(File, [{include_dirs, [boss_files:include_dir() | boss_env:get_env(boss, include_dirs, [])]}])
         end, boss_files:init_file_list(Application)),
     boss_news:start(),
     boss_mail:start([{driver, boss_mail_driver_mock}]),


### PR DESCRIPTION
This change adds a configuration option to allow -including of files from
directories other than the default directory. This is useful (indeed,
necessary) when using ChicagoBoss as part of a larger project with, say,
records defined externally that you want to pull in and use. To use, add a line
like this to boss.config in the 'boss' section:

```
{include_dirs, ["../app/src/include", "../some_other_app/include"]}
```

I realise that the reason something like this probably doesn't currently exist (unless I missed something) is that CB is designed to be used as the top-level system to look after everything that you write. However, in our situation we had an existing pile of code and wanted to add in a CB app (having also looked at a bunch of other web frameworks and not finding anything else that suited our needs quite as well). Our CB app, however, needed to be able to include files from outside its source tree and the include path for the compiler was hard coded and not able to be added to. Putting a full path in the -include directive worked for simple cases, but not where the included files in turn included ones of their own (at least, not without going and modifying all our headers, which already worked fine with the rest of our build system).

My point with all this at is that I understand (and won't be offended :)) if you reject this on the basis that it's not in keeping with how CB is meant to be used. But it might be useful to other crazy people like us :)
