### PR TITLE
Add option to disable built-in log management

### DIFF
--- a/doc-src/api-config.html
+++ b/doc-src/api-config.html
@@ -24,8 +24,8 @@
         <li><code>db_shard_models</code> - A list of models (atoms) which are stored on the shard.</li>
     </ul></li>
     <li><code>include_dirs</code> - List of additional directories to be searched for files specified in <code>-include</code> directives.</li>
-    <li><code>log_dir</code> - Directory in which to keep log files. Location is relative to the project directory. This may be set to <code>none</code> to turn off ChicagoBoss's generation of log files.
-    Log messages will still be passed to Erlang's <code>error_logger</code> module if set to <code>none</code>. Defaults to "log".</li>
+    <li><code>log_dir</code> - Directory in which to keep log files. Location is relative to the project directory. Defaults to "log".</li>
+    <li><code>log_enable</code> - Controls whether ChicagoBoss will generate log files. If this is set to <code>false</code>, log messages will still be sent to Erlang's internal <code>error_logger</code> server and may be handled from there. Defaults to <code>true</code>.</li>
     <li><code>mail_driver</code> - The email delivery driver to use. Valid values are:
     <ul>
         <li><code>boss_mail_driver_smtp</code> - SMTP delivery. If <code>mail_relay</code> is present, it is used as a relay, otherwise direct delivery is attempted.</li>

--- a/src/boss/boss_web_controller.erl
+++ b/src/boss/boss_web_controller.erl
@@ -44,9 +44,10 @@ terminate(_Reason, State) ->
     misultin:stop().
 
 init(Config) ->
-    case boss_env:get_env(log_dir, "log") of
-        none -> ok;
-        LogDir ->
+    case boss_env:get_env(log_enable, true) of
+        false -> ok;
+        true ->
+            LogDir = boss_env:get_env(log_dir, "log"),
             LogFile = make_log_file_name(LogDir),
             ok = filelib:ensure_dir(LogFile),
             error_logger:logfile(close),


### PR DESCRIPTION
This change adds the option to specify 'none' for log_dir config value. The effect is to disable the build-in log management in ChicagoBoss, allowing your to use in your own error_logger based logging system instead.

This is helpful for incorporating a CB app into a larger system where there is already an existing logging framework (handling log rotation etc) based on error_logger.
