### PR TITLE
Add compiler_options config value

### DIFF
--- a/doc-src/api-config.html
+++ b/doc-src/api-config.html
@@ -6,6 +6,7 @@
     <li><code>cache_adapter</code> - The cache adapter to use. Currently the only valid value is <code>memcached_bin</code>.</li>
     <li><code>cache_servers</code> - A list of cache servers (<code>{Host, Port, PoolSize}</code>). Defaults to <code>[{"localhost", 11211, 1}]</code>.
     <li><code>cache_exp_time</code> - The maximum time to keep a cache entry, in seconds. Defaults to 60.</li>
+    <li><code>compiler_options</code> - A list of extra options to be passed to the Erlang compiler invoked by ChicagoBoss. For example, <code>[debug_info]</code> may be specified to make the beam files build with debug information included. Valid options are those available to <a href="http://www.erlang.org/doc/man/compile.html#forms-2">compile:forms/2</a>.</li>
     <li><code>db_host</code> - The hostname of the database. Defaults to "localhost".</li>
     <li><code>db_port</code> - The port of the database. Defaults to 1978.</li>
     <li><code>db_username</code> - The username used for connecting to the database (if needed).</li>

--- a/src/boss/boss_load.erl
+++ b/src/boss/boss_load.erl
@@ -227,13 +227,16 @@ compile_view_erlydtl(Application, ViewPath, OutDir, TranslatorPid) ->
     end.
 
 compile_model(ModulePath, OutDir) ->
-    boss_model_manager:compile(ModulePath, [{out_dir, OutDir}, {include_dirs, [boss_files:include_dir() | boss_env:get_env(boss, include_dirs, [])]}]).
+    boss_model_manager:compile(ModulePath, [{out_dir, OutDir}, {include_dirs, [boss_files:include_dir() | boss_env:get_env(boss, include_dirs, [])]},
+			 {compiler_options, boss_env:get_env(boss, compiler_options, [])}]).
 
 compile_controller(ModulePath, OutDir) ->
-    boss_controller_compiler:compile(ModulePath, [{out_dir, OutDir}, {include_dirs, [boss_files:include_dir() | boss_env:get_env(boss, include_dirs, [])]}]).
+    boss_controller_compiler:compile(ModulePath, [{out_dir, OutDir}, {include_dirs, [boss_files:include_dir() | boss_env:get_env(boss, include_dirs, [])]},
+			 {compiler_options, boss_env:get_env(boss, compiler_options, [])}]).
 
 compile(ModulePath, OutDir) ->
-    boss_compiler:compile(ModulePath, [{out_dir, OutDir}, {include_dirs, [boss_files:include_dir() | boss_env:get_env(boss, include_dirs, [])]}]).
+    boss_compiler:compile(ModulePath, [{out_dir, OutDir}, {include_dirs, [boss_files:include_dir() | boss_env:get_env(boss, include_dirs, [])]},
+			 {compiler_options, boss_env:get_env(boss, compiler_options, [])}]).
 
 load_view_lib(Application, OutDir, TranslatorPid) ->
     {ok, HelperDirModule} = compile_view_dir_erlydtl(boss_files:view_html_tags_path(), 


### PR DESCRIPTION
This allows the user to pass extra compiler options (for example turning on debug_info) into ChicagoBoss's compiler. This, in turn, allows you to do stuff like run dialyzer which is otherwise tricky or impossible.
