### PR TITLE
Fix test_* rebar tasks in 0.8

### DIFF
--- a/priv/rebar/boss_rebar.erl
+++ b/priv/rebar/boss_rebar.erl
@@ -299,7 +299,11 @@ boss_load(BossConf, AppFile) ->
                                                 ok
                                         end 
                                  end, rebar_utils:beams(Dir))
-              end, AllDirs).
+              end, AllDirs),
+    %% Fix starting mimetypes app in boss.erl->ensure_started(mimetypes)
+    %% mimetyps.app not found, adding deps/*/ebin don't work
+    BossPath = boss_config_value(BossConf, boss, path),
+    code:add_path(BossPath++"/deps/mimetypes/ebin").
 
 %%--------------------------------------------------------------------
 %% @doc Start the boss app


### PR DESCRIPTION
In 0.8, since https://github.com/evanmiller/ChicagoBoss/commit/3169166406fae1bab9a7fb5c9363c9f8615b9944#L0R22:
- boss.erl->ensure_started(mimetypes)

test_\* rebar task was failing with: {'EXIT',{{case_clause,{error,{"no such file or directory","mimetypes.app"}}}, mimetypes.app are in deps/mimetypes/ebin dir and code_load deps/*/ebin does not work

Thanks!
