### PR TITLE
Added vm_args

### DIFF
--- a/doc-src/api-config.html
+++ b/doc-src/api-config.html
@@ -7,7 +7,7 @@
     <li><code>cache_servers</code> - A list of cache servers (<code>{Host, Port, PoolSize}</code>). Defaults to <code>[{"localhost", 11211, 1}]</code>.
     <li><code>cache_exp_time</code> - The maximum time to keep a cache entry, in seconds. Defaults to 60.</li>
     <li><code>compiler_options</code> - A list of extra options to be passed to the Erlang compiler invoked by ChicagoBoss. For example, <code>[debug_info]</code> may be specified to make the beam files build with debug information included. Valid options are those available to <a href="http://www.erlang.org/doc/man/compile.html#forms-2">compile:forms/2</a>.</li>
-    <li><code>extra_vmargs</code> - A string of additional vm args that will be appended to the start* commands. For example, limit the TCP ports for distributed Erlang traffic, running Erlang through a firewall you can use <code>{extra_vmargs, "-kernel inet_dist_listen_max 9105 inet_dist_listen_min 9100"}</code></li>
+    <li><code>vm_args</code> - A string of additional vm args that will be appended to the start* commands. For example, limit the TCP ports for distributed Erlang traffic (running Erlang through a firewall), you can use <code>{vm_args, "-kernel inet_dist_listen_max 9105 inet_dist_listen_min 9100"}</code></li>
     <li><code>db_host</code> - The hostname of the database. Defaults to "localhost".</li>
     <li><code>db_port</code> - The port of the database. Defaults to 1978.</li>
     <li><code>db_username</code> - The username used for connecting to the database (if needed).</li>

--- a/priv/rebar/boss_rebar.erl
+++ b/priv/rebar/boss_rebar.erl
@@ -133,9 +133,9 @@ start_cmd(_RebarConf, BossConf, AppFile) ->
     CookieOpt = cookie_option(BossConf),
     
     ErlCmd = erl_command(),
-    ExtraVmargs = extra_vmargs(BossConf),
+    VmArgs = vm_args(BossConf),
     io:format("~s +K true +P ~B -pa ~s -boot start_sasl -config boss -s boss ~s -detached ~s~s~n", 
-        [ErlCmd, MaxProcesses, string:join(EbinDirs, " -pa "), CookieOpt, SNameArg, ExtraVmargs]),
+        [ErlCmd, MaxProcesses, string:join(EbinDirs, " -pa "), CookieOpt, SNameArg, VmArgs]),
     ok.
 
 %%--------------------------------------------------------------------
@@ -158,9 +158,9 @@ start_dev_cmd(_RebarConf, BossConf, AppFile) ->
     ErlCmd = erl_command(), 
     EbinDirs = all_ebin_dirs(BossConf, AppFile),
     CookieOpt = cookie_option(BossConf),
-    ExtraVmargs = extra_vmargs(BossConf),
+    VmArgs = vm_args(BossConf),
     io:format("~s -pa ~s -boss developing_app ~s -boot start_sasl -config boss ~s -s reloader -s boss ~s~s~n", 
-        [ErlCmd, string:join(EbinDirs, " -pa "), AppName, CookieOpt, SNameArg, ExtraVmargs]),
+        [ErlCmd, string:join(EbinDirs, " -pa "), AppName, CookieOpt, SNameArg, VmArgs]),
 	ok.
 
 %%--------------------------------------------------------------------
@@ -400,12 +400,12 @@ host_name() ->
 sname(BossConf, AppFile) ->
     boss_config_value(BossConf, boss, vm_name, io_lib:format("~s@~s", [app_name(AppFile), host_name()])).
 
-extra_vmargs(BossConf) ->
-    case boss_config_value(BossConf, boss, extra_vmargs) of
+vm_args(BossConf) ->
+    case boss_config_value(BossConf, boss, vm_args) of
         {error, _} ->
             "";
-        ExtraVmargs ->
-            " "++ExtraVmargs++" "
+        VmArgs ->
+            " "++VmArgs
     end.
 
 cookie_option(BossConf) ->


### PR DESCRIPTION
vm_args: A string of additional vm args that will be appended to the start\* commands. 

For example, limit the TCP ports for distributed Erlang traffic, running Erlang through a firewall:

<code>{vm_args, "-kernel inet_dist_listen_max 9105 inet_dist_listen_min 9100"}</code>

With this option we can manage all specific needs without to set an option for each one.

Thanks!
