### PR TITLE
Make it possible to access request objects in templates.

### DIFF
--- a/skel/boss.config
+++ b/skel/boss.config
@@ -193,6 +193,9 @@
     {template_tag_modules, []},
     {template_filter_modules, []},
 
+%% Make the request object accessible (as _request) in templates.
+%    {request_in_templates, true},
+
 %%%%%%%%%%%%%%%%%%%%%
 %% Incoming Emails %%
 %%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
In Django, it is possible to access the request object in templates by adding the proper context processor (https://docs.djangoproject.com/en/dev/ref/templates/api/#django-core-context-processors-request). I don't know how to implement this more generally in ChicagoBoss, but here's an attempt at a specific way to do it. It means a setting will be required to use it (as with Django), but it is not a generic context processor replacement. If there's a better way, I'd be very interested to learn more about it.

Briefly tested and seems to work.
