### PR TITLE
Add template context processors ability.

### DIFF
--- a/src/boss/boss_web_controller.erl
+++ b/src/boss/boss_web_controller.erl
@@ -932,6 +932,8 @@ get_template_context(Req, SessionID, Lang, AppInfo, Variables) ->
         ++ lists:map(
              fun({Module, Fun, Arity}) ->
                  case Arity of
+                     0 ->
+                         Module:Fun();
                      2 ->
                          Module:Fun(Req, SessionID);
                      5 ->


### PR DESCRIPTION
This allows for arbitrary modules and funs to be called with given sets of arguments before rendering templates, where the funs return two-tuples of template variables and their values (e.g. <code>{season, "winter"}</code>). These variables will then be valid for all templates.
To enable, add

``` erlang
  {template_context_processors, L}
```

to <code>boss.config</code>, where L is a list of three-tuples, <code>{Module, Fun, Arity}</code> describing the context processor funs to be called. Arity can be either 0, 2 (in which case the fun will be called with Request and SessionID arguments) or 5 (in which case also Lang, AppInfo and Variables) will be added to the call.
### Example:

In src/lib/user_lib.erl, define the fun

``` erlang
request_in_templates(Req, SessionID) ->
    {request, Req}.
```

Then, add

``` erlang
{template_context_processors, [{user_lib, request_in_templates, 2}]}
```

to <code>boss.config</code>. Now the request object will be available to all templates, in the <code>request</code> variable.
