### PR TITLE
Add unroute/3 and unroute/4 that take a module name instead of pid to boss_router.

### DIFF
--- a/src/boss/boss_router.erl
+++ b/src/boss/boss_router.erl
@@ -7,7 +7,7 @@
 %% Exported Functions
 %%
 -export([start/0, start/1, stop/0]).
--export([reload/1, route/2, unroute/4, handle/2, get_all/1, set_controllers/2]).
+-export([reload/1, route/2, unroute/3, unroute/4, handle/2, get_all/1, set_controllers/2]).
 
 %%
 %% API Functions
@@ -28,8 +28,28 @@ reload(Pid) ->
 route(Pid, Url) ->
     gen_server:call(Pid, {route, Url}).
 
-unroute(Pid, Controller, Action, Params) ->
-    gen_server:call(Pid, {unroute, Controller, Action, Params}).
+unroute(undefined, _Controller, _Action, _Params) ->
+    undefined;
+unroute(Pid, Controller, Action, Params) when is_pid(Pid) ->
+    gen_server:call(Pid, {unroute, Controller, Action, Params});
+unroute(Module, Controller, Action, Params) ->
+    case application:get_application(Module) of
+        undefined ->
+            undefined;
+        {ok, Application} ->
+            Pid = boss_web:router_pid(Application),
+            unroute(Pid, unatomize(Controller), unatomize(Action), Params)
+    end.
+unroute(Module, Controller, Action) ->
+    unroute(Module, Controller, Action, []).
+
+unatomize(Element) ->
+    case is_atom(Element) of
+        true ->
+            atom_to_list(Element);
+        false ->
+            Element
+    end.
 
 handle(Pid, StatusCode) ->
     gen_server:call(Pid, {handle, StatusCode}).


### PR DESCRIPTION
For convenience, it's possible to omit Params and pass Controller and Action as atoms.

this function can then be called from controllers like

``` erlang
boss_router:unroute(?MODULE, foo, bar).
```

This pull request replaces #185.
