### PR TITLE
add '_routes' generating macro for experimental Elixir-Support

### DIFF
--- a/README_ELIXIR
+++ b/README_ELIXIR
@@ -51,11 +51,16 @@ should NOT be prefixed with the application name. Example:
 Open up the controller and write a basic module, like:
 
     defmodule MyApplication.PuppyController do
-        import Boss.WebController
+        use Boss.WebController
 
         get :index, [] do
             {:output, "Hello, world!"}
         end
+
+        get about, [] do
+            {:output, "Hello, world!"}
+        end
+
     end
 
 To test it out, start the server and visit:
@@ -127,5 +132,5 @@ This is a comment:
 
 Of course, you're free to continue using Django templates with extension ".dtl"
 if you prefer a dedicated template language.
-    
+
 Enjoy!

--- a/priv/web_controller.ex
+++ b/priv/web_controller.ex
@@ -1,4 +1,13 @@
 defmodule Boss.WebController do
+
+  defmacro __using__(_) do
+    quote do
+      Module.register_attribute __MODULE__, :__routes__, persist: false, accumulate: true
+      @before_compile unquote(__MODULE__)
+      import unquote(__MODULE__)
+    end
+  end
+
   defmacro get(action, tokens, block) do
     handle(:GET, action, tokens, block)
   end
@@ -68,14 +77,44 @@ defmodule Boss.WebController do
   end
 
   defp handle(method, action, tokens, block) do
+    action = to_action(action)
+    route = {action, to_route_tokens(tokens)}
     quote do
+      @__routes__ unquote(route)
       def unquote(action)(var!(req), var!(session_id), unquote(method), unquote(tokens)), unquote(block)
     end
   end
 
   defp handle(method, action, tokens, block, info) do
+    action = to_action(action)
+    route = {action, to_route_tokens(tokens)}
     quote do
+      @__routes__ unquote(route)
       def unquote(action)(var!(req), var!(session_id), unquote(method), unquote(tokens), unquote(info)), unquote(block)
     end
   end
+
+  defp to_action({atom, _, _}), do: atom
+  defp to_action(action),       do: action
+
+  defp to_route_tokens({_, _, nil}), do: []
+  defp to_route_tokens(tokens),      do: lc token inlist tokens, do: to_route_token(token)
+
+  defp to_route_token(token) do
+    case token do
+      {:|, _, [token, _]} -> to_route_token(token)
+      {name, _, _}        -> name
+      value               -> value
+    end
+  end
+
+  defmacro __before_compile__(_) do
+    quote do
+      def _routes(_),    do: @__routes__
+      # simulate a new && instance functions
+      def new(req), do: {__MODULE__, req}
+      def instance(req), do: {__MODULE__, req}
+    end
+  end
+
 end


### PR DESCRIPTION
Difference between Erlang and Elixir controller is in '_routes' functions, that would be generated. This commit will extend macro for generating '_routes' function for Elixir controller too.

Open question is, that this macro doesn't support '_routes' generation from a def definitions.

There are too possible solutions:
Add syntax without implicit definitions like:
defa index(req, session_id, :GET, []) ...
defaction index(req, session_id, :GET, []) ...
as only supportet or make it working with def definitions.
