### PR TITLE
Make web socket handlers more robust to bad code by registering them

### DIFF
--- a/src/boss/boss_service_sup.erl
+++ b/src/boss/boss_service_sup.erl
@@ -64,9 +64,8 @@ start_services(SupPid, Services) ->
 	 ({ServiceUrl, Service}, Acc) ->
 	      {ok, ServicePid} = 
 		  supervisor:start_child(SupPid,
-					 {Service, {boss_service_worker, start_link, [Service]},
+					 {Service, {boss_service_worker, start_link, [Service, ServiceUrl]},
 					  permanent, 5000, worker, [Service]}),
-	      boss_websocket_router:register(ServiceUrl, Service),
 	      Acc ++ [{ok, ServicePid}]
       end, 
       [], 

--- a/src/boss/boss_service_worker.erl
+++ b/src/boss/boss_service_worker.erl
@@ -11,7 +11,7 @@
 -behaviour(gen_server).
 
 %% API
--export([start_link/1]).
+-export([start_link/2]).
 -export([incoming/5, join/4, close/4]).
 
 %% gen_server callbacks
@@ -33,8 +33,8 @@
 %% @spec start_link() -> {ok, Pid} | ignore | {error, Error}
 %% @end
 %%--------------------------------------------------------------------
-start_link(Handler) when is_atom(Handler)->
-    gen_server:start_link({global, Handler}, ?MODULE, [Handler], []).
+start_link(Handler, ServiceUrl) when is_atom(Handler)->
+    gen_server:start_link({global, Handler}, ?MODULE, [Handler, ServiceUrl], []).
 
 incoming(Service, ServiceUrl, WebSocketId, SessionId, Msg) ->
     gen_server:cast({global, Service}, {incoming_msg, ServiceUrl, WebSocketId, SessionId, Msg}).
@@ -60,11 +60,12 @@ close(Service, ServiceUrl, WebSocketId, SessionId) ->
 %%                     {stop, Reason}
 %% @end
 %%--------------------------------------------------------------------
-init([Handler]) when is_atom(Handler) ->
+init([Handler, ServiceUrl]) when is_atom(Handler) ->
     % todo option to init
     try Handler:init() of
 	{ok, Internal} ->
-	    {ok, #state{handler=Handler, internal=Internal}}		
+	    boss_websocket_router:register(ServiceUrl, Handler),
+	    {ok, #state{handler=Handler, internal=Internal}}
     catch Class:Reason ->
 	    error_logger:error_msg(
 	      "** Boss Service Handler ~p terminating in init/0~n"


### PR DESCRIPTION
Make web socket handlers more robust to bad code by registering them
when the worker starts, so that if they crash, they get restarted and
reregistered.
