### PR TITLE
rebar.config should not use 'tag' to reference revisions

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,19 +4,19 @@
     {boss_db, ".*", {git, "git://github.com/evanmiller/boss_db.git",  {tag, "HEAD"}}},
     {tinymq, ".*", {git, "git://github.com/evanmiller/tinymq.git",    {tag, "HEAD"}}},
     {tiny_pq, ".*", {git, "git://github.com/evanmiller/tiny_pq.git",  {tag, "HEAD"}}},
-    {erlydtl, ".*", {git, "git://github.com/evanmiller/erlydtl.git",  {tag, "96dc5b30db"}}},
+    {erlydtl, ".*", {git, "git://github.com/evanmiller/erlydtl.git",  "96dc5b30db"}},
     {jaderl, ".*", {git, "git://github.com/evanmiller/jaderl.git",    {tag, "HEAD"}}},
 
     %% Uncomment the follwing line if you have Erlang R15 and want Elixir support
-    % {elixir, ".*", {git, "git://github.com/elixir-lang/elixir.git",   {tag, "f380d0c93f"}}},
+    % {elixir, ".*", {git, "git://github.com/elixir-lang/elixir.git",   "f380d0c93f"}},
     %% Then copy priv/web_controller.ex to src/ in this directory and recompile
     %% See README_ELIXIR for more details.
 
-    {gen_smtp, ".*", {git, "git://github.com/Vagabond/gen_smtp.git",  {tag, "0558786233"}}},
+    {gen_smtp, ".*", {git, "git://github.com/Vagabond/gen_smtp.git",  "0558786233"}},
     {misultin, ".*", {git, "git://github.com/ostinelli/misultin.git", {tag, "misultin-0.9"}}},
     {mochiweb, ".*", {git, "git://github.com/mochi/mochiweb.git",     {tag, "v2.3.0"}}},
-    {simple_bridge, ".*", {git, "git://github.com/nitrogen/simple_bridge.git", {tag, "2f39fa382d"}}},
-    {poolboy, ".*", {git, "git://github.com/devinus/poolboy.git", {tag, "855802e0cc"}}},
+    {simple_bridge, ".*", {git, "git://github.com/nitrogen/simple_bridge.git", "2f39fa382d"}},
+    {poolboy, ".*", {git, "git://github.com/devinus/poolboy.git", "855802e0cc"}},
     {cowboy, ".*", {git, "git://github.com/extend/cowboy.git", {tag, "0.6.0"}}},
     {mochicow, ".*", {git, "git://github.com/benoitc/mochicow.git", {tag, "HEAD"}}}
   ]}.


### PR DESCRIPTION
See: https://github.com/rebar/rebar/wiki/Dependency-management
