### PR TITLE
Respond to apple-touch-icon.png in root directory.

### DIFF
--- a/src/boss/boss_web_controller.erl
+++ b/src/boss/boss_web_controller.erl
@@ -420,6 +420,8 @@ handle_request(Req, RequestMod, ResponseMod) ->
             Url = lists:nthtail(length(BaseURL), FullUrl),
             Response = simple_bridge:make_response(ResponseMod, {Req, DocRoot}),
             case Url of
+                "/apple-touch-icon.png" = File ->
+                    (Response:file(File)):build_response();
                 "/favicon.ico" = File ->
                     (Response:file(File)):build_response();
                 _ ->


### PR DESCRIPTION
My Nexus 7 tries to grab this file, and presumably, so do other mobile/tablet devices, so I copied the favicon.ico behavior.  
