### PR TITLE
Caching for web controllers

### DIFF
--- a/src/boss/boss_web_controller.erl
+++ b/src/boss/boss_web_controller.erl
@@ -804,7 +804,9 @@ execute_action({Controller, Action, Tokens} = Location, AppInfo, Req, SessionID,
                             Result
                     end;
                 {redirect, Where} ->
-                    {redirect, process_redirect(Controller, Where, AppInfo)}
+                    {redirect, process_redirect(Controller, Where, AppInfo)};
+				{output, Payload, Headers} ->
+					{ok, Payload, Headers}
             end
     end.
 


### PR DESCRIPTION
Hi Evan,

```
Here is the logic that Alex added to allow in-memory caching in our controllers.  It allows a before_ function to return a result itself and prevent the invocation of the controller's action.  The performance impact can be dramatic if you replace an I/O heavy action with a simple cache lookup.  Please let us know if you have any questions or concerns about it.
```
## 

Charlie
