### PR TITLE
Fix for issue #243 (bashism in Makefile)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ edoc:
 #$(ERL) -pa ebin -noshell -eval "boss_doc:run()" -s init stop
 
 app:
-	@(if [[ ! "$(PROJECT)" =~ ^[a-z]+[a-zA-Z0-9_@]*$$ ]] ; then echo "Project name should be a valid Erlang atom."; exit 1; fi)
+	@(if ! echo "$(PROJECT)" | grep -qE '^[a-z]+[a-zA-Z0-9_@]*$$'; then echo "Project name should be a valid Erlang atom."; exit 1; fi)
 	@$(REBAR) create template=skel dest=$(DEST) src=$(PWD) appid=$(PROJECT) skip_deps=true
 
 get-deps:


### PR DESCRIPTION
[[ is a bash/zsh-ism that does not exist in the POSIX /bin/sh, and by
default, GNU make (perhaps others) uses /bin/sh as its shell.  On
systems where /bin/sh is a POSIX-compliant shell, the [[ test fails.

This addresses issue #243.
