### PR TITLE
Update README with correct erlang version information

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ letter and contain only letters, digits, and underscores (for easy compatibility
 Dependencies
 ------------
 
-* Erlang R14B01 or later -
+* Erlang R15B or later -
 
     <http://www.erlang.org/download.html>
 


### PR DESCRIPTION
Erlang 15B is currently needed to `make`. Erlang 14B01 is the current listed dependancy. 
https://github.com/evanmiller/ChicagoBoss/issues/247
