### PR TITLE
Boss executable

### DIFF
--- a/bin/boss
+++ b/bin/boss
@@ -1,0 +1,55 @@
+#!/usr/bin/env sh
+#
+# Chicago Boss Executable
+#
+# @author: Pius Uzamere <pius@alum.mit.edu>
+#
+# Allows the user to easily create a new Chicago Boss application from anywhere, 
+# as long as the Chicago Boss directory is in the user's path.
+#
+# Useful when installing Chicago Boss via Homebrew or similar methods.
+
+
+working_directory="$PWD"
+init_script="$working_directory/init.sh"
+
+# Find the actual directory of Chicago Boss, even if the binary is symlinked.
+
+pushd . > /dev/null
+bossdir="${BASH_SOURCE[0]}";
+if ([ -h "${bossdir}" ]) then
+  while([ -h "${bossdir}" ]) do cd `dirname "$bossdir"`; bossdir=`readlink "${bossdir}"`; done
+fi
+cd `dirname ${bossdir}` > /dev/null
+bossdir=`pwd`;
+popd  > /dev/null
+cd "$bossdir/.."
+bossdir=$PWD
+
+case "${1:-''}" in
+  'new')
+    if [ $# -eq 2 ]
+    then
+      echo "Hold on tight, creating new Chicago Boss app $2 ..."
+      make app PROJECT=$2 PREFIX="$working_directory/" -f "$bossdir/Makefile"
+    else
+      echo Please specify an app name to create a new Chicago Boss application.
+      echo "Usage: boss new APP_NAME or boss start|start-dev|stop|reload|restart|attach"
+    fi 
+    ;;
+
+  'start'|'start-dev'|'stop'|'reload'|'restart'|'attach')
+    if [ -f $init_script ]
+    then
+        sh $init_script $1
+    else
+        echo Sorry, \"boss $1\" may only be run from the root directory of a Chicago Boss application.
+    fi  
+    ;;
+
+  *)
+    echo "Chicago Boss."
+    echo "Usage: boss new APP_NAME or boss start|start-dev|stop|reload|restart|attach"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
Yesterday while writing a [Homebrew](http://mxcl.github.io/homebrew/) formula for Chicago Boss that would install CB into /usr/local, I realized there was no real "boss" command that could be run easily from anywhere to create a new app or manage the app in the current working directory. So I wrote one.

This commit allows devs to do things like "boss new APP" or "boss start", just like one would do with the "rails" command. Because the boss command follows symlinks, it works well both as bin/boss when being run from the ChicagoBoss directory (instead of using "make app project=FOO") or as simply boss in the context of an installation on the user's path.
