### PR TITLE
Bugfix for HTTP 1.0 streaming

### DIFF
--- a/src/boss/boss_web_controller.erl
+++ b/src/boss/boss_web_controller.erl
@@ -486,11 +486,8 @@ build_dynamic_response(App, Request, Response, Url) ->
     Response2 = lists:foldl(fun({K, V}, Acc) -> Acc:header(K, V) end, Response1, Headers),
     case Payload of
         {stream, Generator, Acc0} ->
-            Version = Request:protocol_version(),
-            {Response3, TransferEncoding} = case Version of
-                {1, 1} -> {Response2:data(chunked), chunked};
-                _ -> {Response2, identity}
-            end,
+            TransferEncoding = case Request:protocol_version() of {1, 1} -> chunked; _ -> identity end, 
+            Response3 = Response2:data(chunked),
             Response3:build_response(),
             process_stream_generator(Request, TransferEncoding, RequestMethod, Generator, Acc0);
         _ ->


### PR DESCRIPTION
Wrong branch of mochicow_request:respond called, resulting in bad match exception, as everything related to streaming contains in Body, which supposed to be an io_list in that branch.
It does work with 1.0, as TransferEncoding is still 'identity'.
