### PR TITLE
Static files

### DIFF
--- a/src/boss/boss_web_controller.erl
+++ b/src/boss/boss_web_controller.erl
@@ -425,7 +425,7 @@ handle_request(Req, RequestMod, ResponseMod) ->
 			StaticPrefix = boss_web:static_prefix(App),
 			Url = lists:nthtail(length(BaseURL), FullUrl),
 			Response = simple_bridge:make_response(ResponseMod, {Req, DocRoot}),
-			case lists:member(Url, boss_env:get_env(App, static_files, ["/favicon.ico", "/apple-touch-icon.png", "robots.txt"])) of
+			case lists:member(Url, boss_env:get_env(App, static_files, ["/favicon.ico", "/apple-touch-icon.png", "/robots.txt"])) of
 				true ->
 					(Response:file(Url)):build_response();
 				false ->


### PR DESCRIPTION
proper handling of favicon, robots and other static files in root directory (like different domain verifications files or sitemaps).

new config variable "static_files" used as list of filenames, by default includes 
["/favicon.ico", "/apple-touch-icon.png", "/robots.txt"]
