### PR TITLE
Support for Secure & HttpOnly session cookie flags

### DIFF
--- a/doc-src/api-config.html
+++ b/doc-src/api-config.html
@@ -58,6 +58,8 @@
     <li><code>session_key</code> - Cookie key for sessions. Defaults to "_boss_session"</li>
     <li><code>session_exp_time</code> - Expiration time for the session cookie. Defaults to 1440</li>	
     <li><code>session_mnesia_nodes</code> (optional, Mnesia sessions only) - List of Mnesia nodes, defaults to node()</li>
+    <li><code>session_cookie_http_only</code> - If set to <code>true</code>, the <a href="https://www.owasp.org/index.php/HttpOnly"><code>HttpOnly</code></a> flag will be added to the session cookie. Defaults to <code>false</code>.</li>
+    <li><code>session_cookie_secure</code> - Whether to add the <a href="http://en.wikipedia.org/wiki/HTTP_cookie#Secure_and_HttpOnly"><code>Secure</code></a> flag with the session cookie. Defaults to <code>false</code>.</li>
     <li><code>smtp_server_enable</code> - Enable the SMTP server for incoming mail</li>
     <li><code>smtp_server_address</code> - The address that the SMTP server should bind to. Defaults to <code>{0, 0, 0, 0}</code> (all interfaces).</li>
     <li><code>smtp_server_domain</code> - The domain name of the SMTP server</li>

--- a/skel/boss.config
+++ b/skel/boss.config
@@ -190,6 +190,8 @@
     {session_adapter, mock},
     {session_key, "_boss_session"},
     {session_exp_time, 525600},
+    {session_cookie_http_only, false},
+    {session_cookie_secure, false},
 %    {session_enable, true},
 %    {session_mnesia_nodes, [node()]}, % <- replace "node()" with a node name
 %    {session_domain, ".domain.com"},

--- a/src/boss/boss_web_controller.erl
+++ b/src/boss/boss_web_controller.erl
@@ -640,8 +640,12 @@ process_result(AppInfo, Req, Result, SessionID) ->
                 CookieDomain ->
                     lists:merge(CookieOptions, [{domain, CookieDomain}])
             end,
+            HttpOnly = boss_env:get_env(session_cookie_http_only, false),
+            Secure = boss_env:get_env(session_cookie_secure, false),
+            CookieOptions3 = lists:merge (CookieOptions2, [{http_only, HttpOnly},
+                                                           {secure, Secure}]),
             SessionKey = boss_session:get_session_key(),
-            lists:merge(Headers, [ mochiweb_cookies:cookie(SessionKey, SessionID, CookieOptions2) ])
+            lists:merge(Headers, [ mochiweb_cookies:cookie(SessionKey, SessionID, CookieOptions3) ])
     end,
     {StatusCode, Headers1, Payload}.
 


### PR DESCRIPTION
A little cookie security related patch...

I was not sure whether to make `http_only` enabled by default because I am not aware of any single reason why not. But finally, I decided that it will be safe let CB to behave in the same way as before this commit.

So feel free to change it! :-)
