### PR TITLE
additional case handling if base_url is defined, but empty.

### DIFF
--- a/src/boss/boss_erlydtl_tags.erl
+++ b/src/boss/boss_erlydtl_tags.erl
@@ -54,6 +54,8 @@ url(Variables, Options) ->
     BaseURL = case proplists:get_value(base_url, Options) of
         undefined ->
             boss_web:base_url(list_to_atom(lists:concat([LinkedApp])));
+        "" ->
+            boss_web:base_url(list_to_atom(lists:concat([LinkedApp])));
         ProvidedBaseURL ->
             ProvidedBaseURL
     end,


### PR DESCRIPTION
solves problem with redirecting to another app described here
https://groups.google.com/forum/?fromgroups=#!topic/chicagoboss/LXR_TI6nZQk

also related to issue #280
