### PR TITLE
do not halt server on syntax error in templates

### DIFF
--- a/src/boss/boss_load.erl
+++ b/src/boss/boss_load.erl
@@ -281,10 +281,14 @@ load_view_lib_if_old(Application, TranslatorPid) ->
 
 load_views(Application, OutDir, TranslatorPid) ->
     ModuleList = lists:foldr(fun(Path, Acc) -> 
-                TemplateAdapter = boss_files:template_adapter_for_extension(
-                    filename:extension(Path)),
-                {ok, Module} = compile_view(Application, Path, TemplateAdapter, OutDir, TranslatorPid),
-                [Module|Acc]
+                TemplateAdapter = boss_files:template_adapter_for_extension(filename:extension(Path)),
+                case compile_view(Application, Path, TemplateAdapter, OutDir, TranslatorPid) of
+                    {ok, Module} -> 
+                        [Module|Acc];
+                    {error, Error} -> 
+                        error_logger:error_report(Error),
+                        [undefined|Acc]
+                end
         end, [], boss_files:view_file_list()),
     {ok, ModuleList}.
 


### PR DESCRIPTION
fix for an issue, than CB not started in development and not compiled in production mode
if template had some error, for example {{ var| }}

now,
in dev mode: CB starts normally, print error to log and will work normally,
till problematic view is used and in such case will render correct error description (file, line, error)

in production mode: CB will compile normally, bypassing problematic view and printing error to log.
Server will start and show message about view being missing, if called,  cause it has not being compiled and not added to views list.
