### PR TITLE
More meaningful callback when sending email.

### DIFF
--- a/src/boss/boss_mail.erl
+++ b/src/boss/boss_mail.erl
@@ -21,8 +21,8 @@ send_template(Application, Action, Args, Callback) ->
             send_message(Application, FromAddress, ToAddress, Action, HeaderFields, Variables, [], Callback);
         {ok, FromAddress, ToAddress, HeaderFields, Variables, Options} -> 
             send_message(Application, FromAddress, ToAddress, Action, HeaderFields, Variables, Options, Callback);
-        nevermind ->
-            ok
+        {nevermind, Reason} ->
+            {ok, Reason}
     end.
 
 send(FromAddress, ToAddress, Subject, Body) ->


### PR DESCRIPTION
Currently, callbacks in boss_mail:send_template send don't allow the caller to specify custom arguments. This makes it impossible to wait on the email using bossmq or to identify which email the callback is associated with. This pull request fixes this issue but it is dependent on a similar pull request I executed on gen_smtp (issue #41). 
