### PR TITLE
Semantic versioning support

### DIFF
--- a/src/boss/boss_load.erl
+++ b/src/boss/boss_load.erl
@@ -404,6 +404,12 @@ vcs_vsn_cmd(git) ->
 vcs_vsn_cmd(hg)  -> "hg identify -i";
 vcs_vsn_cmd(bzr) -> "bzr revno";
 vcs_vsn_cmd(svn) -> "svnversion";
+vcs_vsn_cmd("semver") -> vcs_vsn_cmd(semver);
+vcs_vsn_cmd(semver) ->
+    case catch (rebar_vsn_plugin:make_vsn ()) of
+        {'EXIT', _} -> {unknown, "semver"};
+        Vsn         -> {unknown, Vsn}
+    end;
 vcs_vsn_cmd({cmd, _Cmd}=Custom) -> Custom;
 vcs_vsn_cmd(Version) -> {unknown, Version}.
 


### PR DESCRIPTION
For those who use `rebar_vsn_plugin` for semantic versioning,
this is a patch for ChicagoBoss that integrates with our
fork of the `rebar_vsn_plugin`:
  https://github.com/ztmr/rebar_vsn_plugin
(The pull request back to the erlware is pending at the moment.)

WARNING: do not put `rebar_vsn_plugin` into your `rebar_plugins`
in `rebar.config` in the case of any CB applications -- it may
override the standard CB's plugin and you will end up with
broken `.app` file what breaks the app at all (at least missing
list of controllers and so on).

In all the non-CB apps, you can happily use `rebar_vsn_plugin`
as usual.
