### PR TITLE
Pass a new _req template variable

### DIFF
--- a/src/boss/boss_web_controller.erl
+++ b/src/boss/boss_web_controller.erl
@@ -1093,7 +1093,7 @@ render_view({Controller, Template, _}, AppInfo, RequestContext, Variables, Heade
                 AuthInfo -> [{"_before", AuthInfo}]
             end,
             RenderVars = BossFlash ++ BeforeVars ++ [{"_lang", Lang}, {"_session", SessionData},
-                            {"_base_url", AppInfo#boss_app_info.base_url}|Variables],
+                            {"_req", Req}, {"_base_url", AppInfo#boss_app_info.base_url}|Variables],
             case TemplateAdapter:render(Module, [{"_vars", RenderVars}|RenderVars],
                     [{translation_fun, TranslationFun}, {locale, Lang},
                         {host, Req:header(host)}, {application, atom_to_list(AppInfo#boss_app_info.application)},


### PR DESCRIPTION
Provide all the templates with a new `_req` variable
that holds the original web request so that template
can use query and post params directly.

There are situations where it is much more straightforward
than to pass the specific parameters via controller
all the time again and again, across the whole application.
