### PR TITLE
JavaScript view rendering fix and discussion

### DIFF
--- a/src/boss/boss_web_controller.erl
+++ b/src/boss/boss_web_controller.erl
@@ -1043,7 +1043,7 @@ process_action_result({{Controller, _, _}, _, _}, {redirect, Where, Headers}, Ex
     {redirect, process_redirect(Controller, Where, AppInfo), merge_headers(Headers, ExtraHeaders)};
 
 process_action_result(Info, {js, Data, Headers}, ExtraHeaders, AppInfo) ->
-    process_action_result(Info, {output, Data, merge_headers(Headers, [{"Content-Type", "application/javascript"}])},
+    process_action_result(Info, {render, Data, merge_headers(Headers, [{"Content-Type", "application/javascript"}])},
         ExtraHeaders, AppInfo);
 
 process_action_result(Info, {json, Data, Headers}, ExtraHeaders, AppInfo) ->


### PR DESCRIPTION
At least as it was meant originally in b507ac8.
Of course, it is not wrong how it works at the moment, but it's just different than the original idea.

Maybe we should think about `js_raw` and `js_render`, but I think if somebody wants `js_raw`, it can be done with `output` very easily. Much more easily than rendering view.

Also, another question is whether to implement template extension preferences -- for example, if we return `{js, ...}`, the view adapter should prefer `.js` files over `.html`, but once we return `{ok, ...}` the `.html` should be preferred over the others.
This would simplify situations where the `.html` template has its own `.js` template with the same name.
