### PR TITLE
When mail controller says nevermind, a reason must be provided.

### DIFF
--- a/src/boss/boss_mail.erl
+++ b/src/boss/boss_mail.erl
@@ -21,8 +21,8 @@ send_template(Application, Action, Args, Callback) ->
             send_message(Application, FromAddress, ToAddress, Action, HeaderFields, Variables, [], Callback);
         {ok, FromAddress, ToAddress, HeaderFields, Variables, Options} -> 
             send_message(Application, FromAddress, ToAddress, Action, HeaderFields, Variables, Options, Callback);
-        nevermind ->
-            ok
+        {nevermind, Reason} ->
+            {ok, Reason}
     end.
 
 send(FromAddress, ToAddress, Subject, Body) ->


### PR DESCRIPTION
I found it necessary to find out why my mail controller was sending nevermind so that I can update the user regarding what happened.
