### PR TITLE
add support translator for lib module ex: boss_form from ngaranko

### DIFF
--- a/src/boss/boss_lang.erl
+++ b/src/boss/boss_lang.erl
@@ -84,7 +84,10 @@ lang_write_multiline_to_file(IODevice, [Token|Rest]) ->
 	lang_write_multiline_to_file(IODevice, Rest).
 
 extract_strings(App) ->
-    lists:usort(extract_model_strings(App) ++ extract_view_strings(App)).
+    ModuleStrings = extract_module_strings(App),
+    ViewStrings = extract_view_strings(App),
+    ModelStrings = extract_model_strings(App),
+    lists:usort(ModelStrings ++ ViewStrings ++ ModuleStrings).
 
 extract_strings(App, Lang) ->
     AllStrings = extract_strings(App),
@@ -142,6 +145,28 @@ extract_view_strings(App) ->
                         Module:translatable_strings() ++ Module:translated_blocks() ++ Acc
                 end, [], boss_env:get_env(App, view_modules, []) ++ boss_env:get_env(App, view_lib_tags_modules, []))
     end.
+
+extract_module_strings(App) when is_atom(App)->
+    ModulesFiles = boss_files:lib_module_list(App),
+    lists:foldl(fun(File, Acc) ->                                 
+                        Module = list_to_atom(File),
+                        case lists:keysearch(translatable_strings, 
+                                             1, 
+                                             Module:module_info(exports)) of
+                            {value, {translatable_strings, N}} ->
+                                case N of
+                                    1 -> %%Pmode
+                                        DummyModule = boss_model_manager:dummy_instance(Module),
+                                        DummyModule:translatable_strings();                         
+                                    0 -> 
+                                        Module:translatable_strings()
+                                end ++ Acc;
+                            false ->
+                                Acc
+                        end
+                end,
+                [], 
+                ModulesFiles).
 
 process_view_file_blocks(ViewFile) ->
     {ok, BlockStrings} = blocktrans_extractor:extract(ViewFile),


### PR DESCRIPTION
make easier to translate string through cb_admin panel for modules from the lib folder in a given cb app.

ex: boss_form from ngarango.

-module(login_form, [InitialData, Errors, Trans]).
-compile(export_all).

translatable_strings() ->
    [
     "Email", 
     "type email", 
     "Password", 
     "type password",
     "Password is too short"
    ].

form_fields() ->
    [
     {email, [{type, char_field},
                 {label, Trans("Email")},
                 {required, true},
                 {html_options, [{class, "input-large col-xs-12"},
                                {placeholder, Trans("type email")}]}]}
     ,{password, [{type, char_field},
                 {widget, password_input},
                 {label, Trans("Password")},
                 {required, true},
                 {html_options, [{class, "input-large col-xs-12"},
                                {placeholder, Trans("type password")}]}]}
}}]}
    ].
