### PR TITLE
Bypass boss routing for some request path's (cowboy webserver only)

### DIFF
--- a/src/boss/boss_web_controller.erl
+++ b/src/boss/boss_web_controller.erl
@@ -232,7 +232,8 @@ handle_info(timeout, State) ->
             % [{"/", boss_mochicow_handler, []}],
             %Dispatch = [{'_',
 
-            Dispatch = [{'_', AppStaticDispatches ++ BossDispatch}],
+	    ExternalDispatch =  boss_env:get_env(cowboy_routes, []),
+            Dispatch = [{'_', AppStaticDispatches ++ ExternalDispatch ++ BossDispatch}],
             CowboyListener = case boss_env:get_env(ssl_enable, false) of
                 true -> boss_https_listener;
                 _ -> boss_http_listener


### PR DESCRIPTION
Bypass boss routing for some request path's (cowboy web server only).
New boss.config parameter: cowboy_routes. Contains list of standard cowboy routes which is added to Dispatch between Static dispatch and dynamic BossDispatch. Default is [] for full backward compatibility.

Useful when one needs to process some simple requests very fast without using CB infrastructure.
