### PR TITLE
fix an order of messages error

### DIFF
--- a/make-plt.sh
+++ b/make-plt.sh
@@ -7,7 +7,7 @@ echo $PLT
 if [ ! -f $PLT ]; then
    dialyzer  --build_plt --apps kernel stdlib mnesia  inets ssl crypto \
        erts public_key runtime_tools compiler asn1 hipe gs\
-       syntax_tools edoc xmerl \
+       syntax_tools edoc xmerl public_key inet\
        --statistics\
        --output_plt $PLT
    rm deps/riak_core/ebin/*.beam

--- a/rebar.config
+++ b/rebar.config
@@ -33,3 +33,4 @@
 {lib_dirs, ["deps/elixir/lib", "deps"]}.
 
 {cover_enabled, true}.
+{plugins, [rebar_ct]}.

--- a/src/boss/boss_load.erl
+++ b/src/boss/boss_load.erl
@@ -443,7 +443,7 @@ vcs_vsn_cmd(hg)  -> "hg identify -i";
 vcs_vsn_cmd(bzr) -> "bzr revno";
 vcs_vsn_cmd(svn) -> "svnversion";
 vcs_vsn_cmd("semver") ->
-    lager:errror("Use atom 'semver' not string \"semver\""),
+    lager:error("Use atom 'semver' not string \"semver\""),
     vcs_vsn_cmd(semver);
 vcs_vsn_cmd(semver) ->
     case catch (rebar_vsn_plugin:make_vsn ()) of

--- a/src/boss/boss_web_controller.erl
+++ b/src/boss/boss_web_controller.erl
@@ -363,26 +363,17 @@ call_controller_action(Adapter, AdapterInfo, RequestContext) ->
 			    R = Adapter:action(AdapterInfo, RequestContext),
 			    CHandlerPid !{msg,Ref, R}
 	       end),
-    receive_controller_response(Ref, 2).
+    receive_controller_response(Ref).
 
-receive_controller_response(Ref, 1) ->
-    receive
-        {msg, Ref, R} ->
-            R;
-
-        {'EXIT',From, Reason} ->        
-            lager:error("Controller Process Exited ~p ~p", [From, Reason]),
-            {output, "Process Error see console.log for details\n"}
-    end;
-
-receive_controller_response(Ref, 2) ->
+-spec(receive_controller_response(reference()) ->any()).
+receive_controller_response(Ref) ->
     receive
         {msg, Ref, R} ->
             R;
 
         {'EXIT',_From, normal} ->        
             %%lager:error("2 Controller Process Exited normal ~p but response not yet receive", [From]),
-            receive_controller_response(Ref, 1);
+            receive_controller_response(Ref);
 
         {'EXIT',From, Reason} ->        
             lager:error("Controller Process Exited ~p ~p", [From, Reason]),

--- a/src/boss/boss_web_controller_handle_request.erl
+++ b/src/boss/boss_web_controller_handle_request.erl
@@ -67,6 +67,7 @@ build_static_response(App, StaticPrefix, Url, Response) ->
 			Operation(Resp) 
 		end, Response, Ops).
 
+    
 
 -spec(dev_headers(any(), production|development)-> any()).
 dev_headers(Response, development) ->

--- a/test/boss_web_controller_test.erl
+++ b/test/boss_web_controller_test.erl
@@ -26,3 +26,19 @@ make_action_session_id_test() ->
 								       {}, 
 								       undefined, 
 								       ?MODULE)).
+
+receive_controller_response_no_exit_test() ->
+    Ref = make_ref(),
+    self() ! {msg, Ref, ok},
+    ?assertEqual(ok, boss_web_controller:receive_controller_response(Ref)).
+
+receive_controller_response_normal_exit_test() ->
+    Ref = make_ref(),
+    self() ! {'EXIT', {}, normal},
+    self() ! {msg, Ref, ok},
+    ?assertEqual(ok, boss_web_controller:receive_controller_response(Ref)).
+
+receive_controller_response_crash_exit_test() ->
+    Ref = make_ref(),
+    self() ! {'EXIT', Ref, ok},
+    ?assertMatch({output,_}, boss_web_controller:receive_controller_response(Ref)).


### PR DESCRIPTION
in some cases the {'EXIT',_, normal} method was recived before the actual content, so we now ignore it
