### PR TITLE
Update Elixir dependency

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -10,7 +10,7 @@
     {jaderl, ".*", {git, "git://github.com/erlydtl/jaderl.git",    "HEAD"}},
 
     %% Uncomment the follwing line if you have Erlang R16B and want Elixir support
-    %{elixir, ".*", {git, "git://github.com/elixir-lang/elixir.git", {tag, "v0.11.1"}}},
+    %{elixir, ".*", {git, "git://github.com/elixir-lang/elixir.git", {tag, "v0.11.2"}}},
     %% Then copy priv/elixir to src/ in this directory, run "mix deps.get", and recompile
     %% See README_ELIXIR for more details.
 


### PR DESCRIPTION
11.1 doesn't work with the current mix file. In the future, we should probably lock the library versions at compatible versions, however, this fixes the immediate problem.
