### PR TITLE
Fix redirect with headers

### DIFF
--- a/src/boss/boss_web_controller_render.erl
+++ b/src/boss/boss_web_controller_render.erl
@@ -110,6 +110,8 @@ expand_action_result({render_other, OtherLocation, Data}) ->
     {render_other, OtherLocation, Data, []};
 expand_action_result({redirect, Where}) ->
     {redirect, Where, []};
+expand_action_result({redirect, Where, Headers}) ->
+    {redirect, Where, Headers};
 expand_action_result({js, Data}) ->
     {js, Data, []};
 expand_action_result({json, Data}) ->


### PR DESCRIPTION
otherwise it ends up with the error

```
"Action returned an invalid return ~p ", [Other]
```

with e.g.

```
{redirect,"http://example.com/",[{"Set-Cookie","user_id=abcdefgh; Version=1; Path=/"}]}
```
