### PR TITLE
Add charset specification support to boss_mail.

### DIFF
--- a/doc-src/api-mail-controller.html
+++ b/doc-src/api-mail-controller.html
@@ -47,6 +47,7 @@
     <ul>
         <li><p><code>attachments</code> - a list of tuples representing email attachments. Each attachment should consist of: <code>{FileName, MimeType, Contents}</code>. In this case <code>FileName</code> simply refers to how the file will be named in the email (and is not necessarily a file on the local file system). The file's <code>Contents</code> should be an io_list.</p></li>
         <li><p><code>template</code> - a string with the name of another template to use for rendering (assuming you don't want the default template, which is just the same as the function name).</p></li>
+        <li><p><code>charset</code> - specify which character set to use for the outgoing email (see <a href="#charset">Specifying character set</a>).</li>
     </ul>
 </ul>
 <p><strong>Formatting.</strong> If templates ending only in ".txt" are present, the message will be sent in plain-text; if templates ending only in ".html" are present, the message will be sent as HTML; but if both ".txt" and ".html" templates are present, the message will be sent as a a MIME multi-part message with alternative plain-text and HTML representations.</p>
@@ -67,4 +68,25 @@
     <li>The IP address of the sender</li>
 </ul>
 <p>The <code>authorize_/3</code> function should return <code>true</code> if the user should be permitted to send email to the controller, or <code>false</code> otherwise.</p>
+
+<a name="charset"></a><h2>Specifying character set</h2>
+
+<p>To specify the character set of the outgoing email, provide the option <code>{charset, &lt;CHARSET&gt;}</code> in the options part of the return value from the controller function, example:</p>
+
+<div class="code">
+<pre>
+my_function(FromAddress, ToAddress) ->
+    {
+      ok,
+      FromAddress,
+      ToAddress,
+      [
+       {"Subject", "My amazing UTF-8 email!"}
+      ],
+      [{template_parameter, template_parameter_value()}],
+      [{charset, "utf-8"}]
+    }.
+</pre>
+</div>
+
 {% endblock %}

--- a/src/boss/boss_mail.erl
+++ b/src/boss/boss_mail.erl
@@ -14,13 +14,13 @@
 -spec build_message(_,atom(),[{_,_}],_,[any()]) -> [[any()],...].
 -spec convert_unix_newlines_to_dos(binary() | [any()]) -> [any()].
 -spec convert_unix_newlines_to_dos([any()],[any()]) -> [any()].
--spec build_message_header([{_,_}],[[[any()] | 61 | 95] | 1..255,...]) -> [[any(),...]].
+-spec build_message_header([{_,_}],[[[any()] | 61 | 95] | 1..255,...],_) -> [[any(),...]].
 -spec add_fields([{_,_}],[any()],[[any(),...]]) -> [[any(),...]].
--spec build_message_body_attachments(_,_,_,[{_,_} | {_,_,binary() | maybe_improper_list(any(),binary() | [])}],_) -> 'undefined' | {[[[any()] | 61 | 95] | 1..255,...],_}.
--spec build_message_body(_,_,_,_) -> 'undefined' | {[[[any()] | 61 | 95] | 1..255,...],_}.
+-spec build_message_body_attachments(_,_,_,[{_,_} | {_,_,binary() | maybe_improper_list(any(),binary() | [])}],_,_) -> 'undefined' | {[[[any()] | 61 | 95] | 1..255,...],_}.
+-spec build_message_body(_,_,_,_,_) -> 'undefined' | {[[[any()] | 61 | 95] | 1..255,...],_}.
 -spec render_view(types:application(),{_,[104 | 108 | 109 | 116 | 120,...]},_,_) -> any().
--spec render_multipart_view([{_,_} | {_,_,binary() | maybe_improper_list(any(),binary() | [])},...],[[[any()] | 61 | 95],...]) -> [[any(),...],...].
--spec render_multipart_view1([{_,_} | {_,_,binary() | maybe_improper_list(any(),binary() | [])}],[[[any()] | 61 | 95],...]) -> [any(),...].
+-spec render_multipart_view([{_,_} | {_,_,binary() | maybe_improper_list(any(),binary() | [])},...],[[[any()] | 61 | 95],...],_) -> [[any(),...],...].
+-spec render_multipart_view1([{_,_} | {_,_,binary() | maybe_improper_list(any(),binary() | [])}],[[[any()] | 61 | 95],...],_) -> [any(),...].
 -spec wrap_to_76(binary()) -> [binary(),...].
 -spec wrap_to_76(binary(),[<<_:16,_:_*592>>]) -> binary().
 
@@ -64,7 +64,9 @@ do_send(FromAddress, ToAddress, Subject, Body, Callback) ->
     MessageHeader = build_message_header([
                                           {"Subject", Subject},
                                           {"To", ToAddress},
-                                          {"From", FromAddress}], "text/plain"), 
+                                          {"From", FromAddress}],
+                                         "text/plain",
+                                         undefined),
     gen_server:call(boss_mail, {deliver, FromAddress, ToAddress, 
             fun() -> [MessageHeader, "\r\n", convert_unix_newlines_to_dos(Body)] end,
             Callback}).
@@ -77,8 +79,9 @@ build_message(App, Action, HeaderFields, Variables, Options) ->
     ContentLanguage             = proplists:get_value("Content-Language", HeaderFields),
     EffectiveAction             = proplists:get_value(template, Options, Action),
     Attachments                 = proplists:get_value(attachments, Options, []),
-    {MimeType, MessageBody}     = build_message_body_attachments(App, EffectiveAction, Variables, Attachments, ContentLanguage),
-    MessageHeader = build_message_header(HeaderFields, MimeType),
+    CharSet                     = proplists:get_value(charset, Options),
+    {MimeType, MessageBody}     = build_message_body_attachments(App, EffectiveAction, Variables, Attachments, ContentLanguage, CharSet),
+    MessageHeader = build_message_header(HeaderFields, MimeType, CharSet),
     [MessageHeader, "\r\n", convert_unix_newlines_to_dos(MessageBody)].
 
 convert_unix_newlines_to_dos(Body) when is_binary(Body) ->
@@ -97,12 +100,20 @@ convert_unix_newlines_to_dos([H|T], Acc) when is_binary(H); is_list(H) ->
 convert_unix_newlines_to_dos([H|T], Acc) ->
     convert_unix_newlines_to_dos(T, [H|Acc]).
 
-build_message_header(HeaderFields, DefaultMimeType) ->
+build_content_type(ContentType, CharSet) ->
+    case CharSet of
+        undefined ->
+            ContentType;
+        _ ->
+            io_lib:format("~s; charset=~s", [ContentType, CharSet])
+    end.
+
+build_message_header(HeaderFields, DefaultMimeType, CharSet) ->
     MessageID = case proplists:get_value("Message-ID", HeaderFields) of
         undefined -> smtp_util:generate_message_id();
         Other -> Other
     end,
-    ContentType = proplists:get_value("Content-Type", HeaderFields, DefaultMimeType),
+    ContentType = build_content_type(proplists:get_value("Content-Type", HeaderFields, DefaultMimeType), CharSet),
     Date = proplists:get_value("Date", HeaderFields, erlydtl_dateformat:format("r")),
     AllHeaders = [{"Date", Date}, {"Content-Type", ContentType},
         {"MIME-Version", "1.0"}, {"Message-ID", MessageID} | HeaderFields],
@@ -118,15 +129,15 @@ add_fields([{Key, Value}|Rest], Seen, Acc) ->
             add_fields(Rest, Seen, Acc)
     end.
 
-build_message_body_attachments(App, Action, Variables, [], ContentLanguage) ->
-    build_message_body(App, Action, Variables, ContentLanguage);
-build_message_body_attachments(App, Action, Variables, Attachments, ContentLanguage) ->
+build_message_body_attachments(App, Action, Variables, [], ContentLanguage, CharSet) ->
+    build_message_body(App, Action, Variables, ContentLanguage, CharSet);
+build_message_body_attachments(App, Action, Variables, Attachments, ContentLanguage, CharSet) ->
     Boundary = smtp_util:generate_message_boundary(),
-    {MimeType, MessageBody} = build_message_body(App, Action, Variables, ContentLanguage),
+    {MimeType, MessageBody} = build_message_body(App, Action, Variables, ContentLanguage, CharSet),
     {"multipart/mixed; boundary=\""++Boundary++"\"",
-        render_multipart_view([{MimeType, MessageBody}|Attachments], Boundary)}.
+        render_multipart_view([{MimeType, MessageBody}|Attachments], Boundary, CharSet)}.
 
-build_message_body(App, Action, Variables, ContentLanguage) ->
+build_message_body(App, Action, Variables, ContentLanguage, CharSet) ->
     HtmlResult = render_view(App, {Action, "html"}, Variables, ContentLanguage),
     TextResult = render_view(App, {Action, "txt"}, Variables, ContentLanguage),
     case HtmlResult of
@@ -144,7 +155,7 @@ build_message_body(App, Action, Variables, ContentLanguage) ->
                     {"multipart/alternative; boundary=\""++Boundary++"\"",
                         render_multipart_view(
                             [{"text/plain", TextView}, 
-                                {"text/html", HtmlView}], Boundary)}
+                                {"text/html", HtmlView}], Boundary, CharSet)}
             end
     end.
 
@@ -163,22 +174,22 @@ render_view(App, {Action, Extension}, Variables, ContentLanguage) ->
             undefined
     end.
 
-render_multipart_view(Parts, Boundary) ->
+render_multipart_view(Parts, Boundary, CharSet) ->
     ["This is a message with multiple parts in MIME format.\r\n",
-        render_multipart_view1(Parts, Boundary)].
+        render_multipart_view1(Parts, Boundary, CharSet)].
 
-render_multipart_view1([], Boundary) ->
+render_multipart_view1([], Boundary, _) ->
     ["--", Boundary, "--"];
-render_multipart_view1([{FileName, MimeType, Body}|Rest], Boundary) ->
+render_multipart_view1([{FileName, MimeType, Body}|Rest], Boundary, CharSet) ->
     ["--", Boundary, 
-        "\r\n", "Content-Type: ", MimeType, 
+        "\r\n", "Content-Type: ", build_content_type(MimeType, CharSet), 
         "\r\n", "Content-Disposition: attachment; filename=", FileName, 
         "\r\n", "Content-Transfer-Encoding: base64",
         "\r\n\r\n",
-        wrap_to_76(base64:encode(erlang:iolist_to_binary(Body))), "\r\n", render_multipart_view1(Rest, Boundary)];
-render_multipart_view1([{MimeType, Body}|Rest], Boundary) ->
-    ["--", Boundary, "\r\n", "Content-Type: ", MimeType, "\r\n\r\n",
-        Body, "\r\n", render_multipart_view1(Rest, Boundary)].
+        wrap_to_76(base64:encode(erlang:iolist_to_binary(Body))), "\r\n", render_multipart_view1(Rest, Boundary, CharSet)];
+render_multipart_view1([{MimeType, Body}|Rest], Boundary, CharSet) ->
+    ["--", Boundary, "\r\n", "Content-Type: ", build_content_type(MimeType, CharSet), "\r\n\r\n",
+        Body, "\r\n", render_multipart_view1(Rest, Boundary, CharSet)].
 
 
 wrap_to_76(String) ->


### PR DESCRIPTION
Currently, there is (AFAICT) no way to specify character set for outgoing email. This is a suggestion for a way to support custom charsets.
