### PR TITLE
Update rebar.config

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -8,17 +8,17 @@
 
 {template_dir, "."}.
 {deps, [
-        % maintained by CB team
-        {boss_db,               ".*",   {git, "git://github.com/ChicagoBoss/boss_db.git",       "v0.8.9a"}},
-        {tinymq,                ".*",   {git, "git://github.com/ChicagoBoss/tinymq.git",    "HEAD"}},
-        {tiny_pq,               ".*",   {git, "git://github.com/ChicagoBoss/tiny_pq.git",   "v0.8.9"}},
-        {mochicow,              ".*",   {git, "git://github.com/ChicagoBoss/mochicow.git", "r16-compat"}},
-
         % maintained by others
         {lager,                 ".*",   {git, "git://github.com/basho/lager.git", {tag, "2.0.1"}}},
         {erlando,               ".*",   {git, "git://github.com/travelping/erlando.git",    "HEAD"}},
         {erlydtl,               ".*",   {git, "git://github.com/erlydtl/erlydtl.git",       "HEAD"}},
         {jaderl,                ".*",   {git, "git://github.com/erlydtl/jaderl.git",        "HEAD"}},
+
+        % maintained by CB team
+        {boss_db,               ".*",   {git, "git://github.com/ChicagoBoss/boss_db.git",       "v0.8.9a"}},
+        {tinymq,                ".*",   {git, "git://github.com/ChicagoBoss/tinymq.git",    "HEAD"}},
+        {tiny_pq,               ".*",   {git, "git://github.com/ChicagoBoss/tiny_pq.git",   "v0.8.9"}},
+        {mochicow,              ".*",   {git, "git://github.com/ChicagoBoss/mochicow.git", "r16-compat"}},
         
         %% Uncomment the follwing line if you have Erlang R16B and want Elixir support
         %{elixir,               ".*",   {git, "git://github.com/elixir-lang/elixir.git", {tag, "v0.12.0"}}},


### PR DESCRIPTION
latest version don't compile, on my machine:
seem i need to change order of deps to make it compile, put lager and erlando before other.

/home/mihawk/vagrant/ChicagoBoss/deps/cowlib/src/cow_http.erl:none: undefined parse transform 'lager_transform'
ERROR: compile failed while processing /home/mihawk/vagrant/ChicagoBoss/deps/cowlib: rebar_abort
make: **\* [all] Error 1
