### PR TITLE
New (fifth) parameter in boss_flash:add - Data::term()

### DIFF
--- a/src/boss/boss_flash.erl
+++ b/src/boss/boss_flash.erl
@@ -1,5 +1,5 @@
 -module(boss_flash).
--export([get_and_clear/1, add/4, add/3]).
+-export([get_and_clear/1, add/5, add/4, add/3]).
 
 %% @spec get_and_clear(SessionID) -> [Message]
 %% @doc Retrieve the current flash messages for `SessionID' and flush the message stack.
@@ -14,16 +14,21 @@ get_and_clear(SessionID) ->
 %% @spec add(SessionID, Type, Title) -> ok | {error, Reason}
 %% @doc Add a message to the flash message stack for `SessionID'.
 add(SessionID, Type, Title) ->
-    add(SessionID, Type, Title, undefined).
+    add(SessionID, Type, Title, undefined, undefined).
 	
 %% @spec add(SessionID, Type, Title, Message) -> ok | {error, Reason}
 %% @doc Add a message to the flash message stack for `SessionID'.
 add(SessionID, Type, Title, Message) ->
-    Msg = [{method, atom_to_list(Type)}, {title, Title}, {message, Message}],
-    Flash = case boss_session:get_session_data(SessionID, boss_flash) of
-		undefined ->
-		    [Msg];
-		ExistingFlash ->
-		    [Msg|ExistingFlash]
-	    end,
-    boss_session:set_session_data(SessionID, boss_flash, Flash).
+    add(SessionID, Type, Title, Message, undefined).
+
+%% @spec add(SessionID, Type, Title, Message, Data) -> ok | {error, Reason}
+%% @doc Add a message to the flash message stack for `SessionID'.
+add(SessionID, Type, Title, Message, Data) ->
+  Msg = [{method, atom_to_list(Type)}, {title, Title}, {message, Message}, {data, Data}],
+  Flash = case boss_session:get_session_data(SessionID, boss_flash) of
+            undefined ->
+              [Msg];
+            ExistingFlash ->
+              [Msg|ExistingFlash]
+          end,
+  boss_session:set_session_data(SessionID, boss_flash, Flash).


### PR DESCRIPTION
Sometimes MessageType, Message and Title is not enough - in my case I need to show both title, translated message and something like "11/100" (success count/total count).  
So I added a new parameter - arbitrary data. By default its' value is 'undefined'.

It can be accessed in templates with code like this:

```
{% for flash in boss_flash %}
    {{ flash.data }}
{% endfor %}

This change should be 100% backward compatible
```
