### PR TITLE
Fix caching pages

### DIFF
--- a/src/boss/boss_web_controller_render.erl
+++ b/src/boss/boss_web_controller_render.erl
@@ -98,6 +98,8 @@ process_redirect(_, Where, _) ->
     Where.
 
 
+expand_action_result({cached_page, CachedResult}) ->
+    expand_action_result(CachedResult);
 expand_action_result(Keyword) when Keyword =:= ok; Keyword =:= render ->
     {render, [], []};
 expand_action_result({Keyword, Data}) when Keyword =:= ok; Keyword =:= render ->


### PR DESCRIPTION
I wanted to use memcached and I followed instructions from this page:
[API controller](http://www.chicagoboss.org/api-controller.html),
but it gave me an error.

I found out, that in `boss_controller_adapter_mod`, `RequestContext` doesn't have
`action` and `tokens` keys and that causes the error.

It was due to a typo in `boss_web_controller_render`,
Instead of `RequestContext3`, there was `RequestContext` passed to `apply_middle_filters`.
Docs state, that request context always has `action` and `tokens` fields
and this is fixed by first commit.

But after that I got `Action returned an invalid return {cached_page,{ok,"HELLO, WORLD!",[]}}`
I've added case clause for cached page in second commit, but I am not sure,
if this is right way to fix that, because those data are passed to `render_view`
and I think cached pages should be rendered immediately.
