### PR TITLE
Use erlydtl rather than erlydtl_compiler.

### DIFF
--- a/src/boss/boss_load.erl
+++ b/src/boss/boss_load.erl
@@ -299,7 +299,7 @@ view_doc_root(ViewPath) ->
                 end;
             (_, Best) ->
                 Best
-        end, "", 
+        end, "",
         [boss_files_util:web_view_path(), boss_files_util:mail_view_path()]).
 
 compile_view_dir_erlydtl(Application, LibPath, Module, OutDir, TranslatorPid) ->
@@ -308,18 +308,21 @@ compile_view_dir_erlydtl(Application, LibPath, Module, OutDir, TranslatorPid) ->
     ExtraTagHelpers	= boss_env:get_env(template_tag_modules, []),
     ExtraFilterHelpers	= boss_env:get_env(template_filter_modules, []),
     lager:info("Compile Modules ~p  ~p", [LibPath,Module]),
-    Res			= erlydtl_compiler:compile_dir(LibPath, Module,
-        [{doc_root, view_doc_root(LibPath)}, {compiler_options, []}, {out_dir, OutDir}, 
-            {custom_tags_modules, TagHelpers ++ ExtraTagHelpers ++ [boss_erlydtl_tags]},
-            {custom_filters_modules, FilterHelpers ++ ExtraFilterHelpers},
-            {blocktrans_fun, fun(BlockString, Locale) ->
-                    case boss_translator:lookup(TranslatorPid, BlockString, Locale) of
-                        undefined -> default;
-                        Body -> list_to_binary(Body)
-                    end
-            end}]),
+    Res =
+        erlydtl:compile_dir(LibPath, Module,
+                            [{doc_root, view_doc_root(LibPath)}, {compiler_options, []}, {out_dir, OutDir},
+                             {custom_tags_modules, TagHelpers ++ ExtraTagHelpers ++ [boss_erlydtl_tags]},
+                             {custom_filters_modules, FilterHelpers ++ ExtraFilterHelpers},
+                             {blocktrans_fun,
+                              fun(BlockString, Locale) ->
+                                      case boss_translator:lookup(TranslatorPid, BlockString, Locale) of
+                                          undefined -> default;
+                                          Body -> list_to_binary(Body)
+                                      end
+                              end}]),
     case Res of
-        ok -> {ok, Module};
+        ok ->
+            {ok, Module};
         Err -> Err
     end.
 

--- a/src/boss/template_adapters/boss_template_adapter_erlydtl.erl
+++ b/src/boss/template_adapters/boss_template_adapter_erlydtl.erl
@@ -38,7 +38,8 @@ compile_file(ViewPath, Module, Options) ->
 				  CompilerOptions, Locales, DocRoot, TagHelpers, FilterHelpers,
 				  ExtraTagHelpers, ExtraFilterHelpers),
     case Res of
-        ok -> {ok, Module};
+        ok ->
+            {ok, Module};
         Err -> Err
     end.
 
@@ -59,6 +60,6 @@ compile(ViewPath, Module, HelperDirModule, TranslatorPid, OutDir,
 			      end
 		      end},
 		     {blocktrans_locales, Locales}],
-    erlydtl_compiler:compile(ViewPath,
-			     Module,
-                             CompileParams).
+    erlydtl:compile(ViewPath,
+                    Module,
+                    CompileParams).


### PR DESCRIPTION
This, together with https://github.com/erlydtl/erlydtl/pull/122 seems to make the compilation errors go away.

I wouldn't be surprised if it's not 100% perfect though, as I'm going a bit batty from having stared at all this compile stuff for hours.
