### PR TITLE
Fix filters with custom action result

### DIFF
--- a/src/boss/boss_web_controller_render.erl
+++ b/src/boss/boss_web_controller_render.erl
@@ -97,9 +97,6 @@ process_redirect(Controller, [{_, _}|_] = Where, AppInfo) ->
 process_redirect(_, Where, _) ->
     Where.
 
-
-expand_action_result({cached_page, CachedResult}) ->
-    expand_action_result(CachedResult);
 expand_action_result(Keyword) when Keyword =:= ok; Keyword =:= render ->
     {render, [], []};
 expand_action_result({Keyword, Data}) when Keyword =:= ok; Keyword =:= render ->
@@ -131,8 +128,7 @@ expand_action_result({Directive,_, _}) when is_list(Directive) ->
     lager:error("Action returned an invalid return ~p should be an atom not a string", [Directive]),
     {output, "bad return value from controller action\n",[]};
 expand_action_result(Other) ->
-    lager:error("Action returned an invalid return ~p ", [Other]),
-    {output, Other, []}.
+    Other.
 
 
 


### PR DESCRIPTION
In my last pull request I fixed error while using caching pages:
https://github.com/ChicagoBoss/ChicagoBoss/pull/423
by adding `cached_page` in `boss_web_controller_render:expand_action_result`.
It looks, that there is another atom `page` and that both of them should be directly passed from before_filter to middle_filter.
(in last pull request I stripped it: `{cached_page, CachedResult}` -> `CachedResult`,
which was a mistake).

I also think, that it is good idea to be able to pass custom atoms from before_filters to middle_filters
and this commit adds this.

I am sorry, but currently I don't have time to write tests in common test.
