### PR TITLE
Use erlydtl 0.8.2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -17,7 +17,7 @@
         % maintained by others
         {lager,                 ".*",   {git, "git://github.com/basho/lager.git", 	    	{tag, "2.0.1"}}},
         {erlando,               ".*",   {git, "git://github.com/travelping/erlando.git",    	"HEAD"}},
-        {erlydtl,               ".*",   {git, "git://github.com/erlydtl/erlydtl.git",       	{tag, "0.8.1"}}},
+        {erlydtl,               ".*",   {git, "git://github.com/erlydtl/erlydtl.git",       	{tag, "0.8.2"}}},
         {jaderl,                ".*",   {git, "git://github.com/erlydtl/jaderl.git", 		"HEAD"}},
         
         %% Uncomment the follwing line if you have Erlang R16B and want Elixir support
@@ -40,8 +40,8 @@
 		{out_dir,    "ebin"},
 		{source_ext, ".dtl"},
 		{module_ext, ""},
-		{compiler_options, [report, return, debug_info]}
-
+		{compiler_options, [debug_info]},
+		report, return
     ]}.
 {lib_dirs, ["deps/elixir/lib", "deps"]}.
 


### PR DESCRIPTION
The `erlydtl:compile_dir` function was fixed in 0.8.2.
Fixes #419.

Also, the `report` and `return` options should now go directly into the erlydtl options, rather than into the `compiler_options` property; otherwise those options will not be treated by erlydtl, but only affect the erlang compiler, which is not what you want.
