### PR TITLE
Stop cowboy correctly in boss_web_controller:terminate/2.

### DIFF
--- a/src/boss/boss_web_controller.erl
+++ b/src/boss/boss_web_controller.erl
@@ -37,7 +37,8 @@ terminate(_Reason, State) ->
         mochiweb ->
             mochiweb_http:stop();
         cowboy   ->
-            cowboy:stop()
+            cowboy:stop_listener(boss_http_listener),
+            cowboy:stop_listener(boss_https_listener)
     end,
     application:stop(elixir).
 


### PR DESCRIPTION
stop/0 doesn't seem to be part of cowboy's API. As far as I can tell, this should be the way to stop the listeners.
