### PR TITLE
Fix silent errors in views

### DIFF
--- a/src/boss/boss_web_controller_render.erl
+++ b/src/boss/boss_web_controller_render.erl
@@ -238,15 +238,20 @@ render_with_template(Controller, Template, AppInfo, RequestContext,
                  end,
     RenderVars = BossFlash ++ BeforeVars ++ [{"_lang", Lang}, {"_session", SessionData},
                                              {"_req", Req}, {"_base_url", AppInfo#boss_app_info.base_url} | Variables],
-    case TemplateAdapter:render(Module, [{"_vars", RenderVars}|RenderVars],
-            [{translation_fun, TranslationFun}, {locale, Lang},
-                {host, Req:header(host)}, {application, atom_to_list(AppInfo#boss_app_info.application)},
-                {controller, Controller}, {action, Template},
-                {router_pid, AppInfo#boss_app_info.router_pid}]) of
-        {ok, Payload} ->
-            {ok, Payload, boss_web_controller:merge_headers([{"Content-Language", Lang}], Headers)};
-        Err ->
-            Err
+    try 
+        case TemplateAdapter:render(Module, [{"_vars", RenderVars}|RenderVars],
+                [{translation_fun, TranslationFun}, {locale, Lang},
+                    {host, Req:header(host)}, {application, atom_to_list(AppInfo#boss_app_info.application)},
+                    {controller, Controller}, {action, Template},
+                    {router_pid, AppInfo#boss_app_info.router_pid}]) of
+            {ok, Payload} ->
+                {ok, Payload, boss_web_controller:merge_headers([{"Content-Language", Lang}], Headers)};
+            Err ->
+                Err
+        end
+    catch
+        Class:Error ->
+            lager:error("Error in view ~p ~p ~p ~p", [Module, Class, Error, erlang:get_stacktrace()])
     end.
 
 load_result(Controller, Template, AppInfo, TryExtensions) ->


### PR DESCRIPTION
Hi, I had problem, which was hard to debug.
I wrote something like that in my view:
`myvariable.myattribute|escapejs`
and it crashed with two errors:

``` erlang
[error] Ranch listener boss_http_listener had connection process started with cowboy_protocol:start_link/4 at <0.345.0> exit with reason: {{case_clause,closed},[{cowboy_protocol,execute,4,[{file,"src/cowboy_protocol.erl"},{line,529}]}]}

[error] Error in process <0.345.0> on node 'myapp@myhost' with exit value: {{case_clause,closed},[{cowboy_protocol,execute,4,[{file,"src/cowboy_protocol.erl"},{line,529}]}]}
```

It doesn't give any helpful information,
so I propose to surround
`TemplateAdapter:render` in `try ... catch`.
This way I can see something like this:

``` erlang
[error] Error in view myapp_view_myview_show_html error function_clause [{erlydtl_filters,escapejs,[undefined],[{file,"src/erlydtl_filters.erl"},{line,298}]},{loris_view_admin_programme_show_html,'-render_internal/2-fun-1-',3,[]},{lists,mapfoldl,3,[{file,"lists.erl"},{line,1339}]},{lists,mapfoldl,3,[{file,"lists.erl"},{line,1340}]},{erlydtl_runtime,forloop,3,[{file,"src/erlydtl_runtime.erl"},{line,260}]},{loris_view_admin_programme_show_html,render_internal,2,[]},{loris_view_admin_programme_show_html,render,2,[]},{boss_web_controller_render,render_with_template,11,[{file,"src/boss/boss_web_controller_render.erl"},{line,242}]}]
```

Which clearly tells me, that I wanted to use filter on NULL value.
The fix was easy, but debugging this took me some time.

I know, that Erlang uses "let it crash" policy,
but for some reason crashes in erlydtl are not displayed.
