### PR TITLE
Follow redirect headers

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -21,8 +21,7 @@
         % maintained by others
         {lager,                 ".*",   {git, "git://github.com/basho/lager.git",               {tag, "2.0.3"}}},
         {erlando,               ".*",   {git, "git://github.com/travelping/erlando.git",        {branch, "master"}}},
-%        {erlydtl,               ".*",   {git, "git://github.com/erlydtl/erlydtl.git",           {tag, "0.9.3"}}},
-        {erlydtl,               ".*",   {git, "git://github.com/erlydtl/erlydtl.git",           {tag, "0.8.0"}}},
+        {erlydtl,               ".*",   {git, "git://github.com/erlydtl/erlydtl.git",           {tag, "0.9.3"}}},
         {jaderl,                ".*",   {git, "git://github.com/erlydtl/jaderl.git",            {branch, "master"}}},
         
         %% Uncomment the follwing line if you have Erlang R16B and want Elixir support


### PR DESCRIPTION
This is for the testing framework.

This adds a follow_redirect variant that lets you pass headers (cookies, for instance) in the get request that happens when you follow a redirect.
