### PR TITLE
Add missing date() type to the api-record doc

### DIFF
--- a/doc-src/api-record.html
+++ b/doc-src/api-record.html
@@ -24,6 +24,7 @@ BossRecords are <em>specially compiled parameterized modules</em> that follow th
         <li><code>binary()</code></li>
         <li><code>integer()</code></li>
         <li><code>float()</code></li>
+        <li><code>date()</code></li>
         <li><code>datetime()</code></li>
         <li><code>timestamp()</code></li>
         <li><code>boolean()</code></li>


### PR DESCRIPTION
According to the [BossDB README](https://github.com/ChicagoBoss/boss_db#validating-and-saving) the datatype `date()` is missing in the [API Reference](http://www.chicagoboss.org/api-record.html)
