### PR TITLE
Patch allows us to mofify not_found response with {redirect, Location}...

### DIFF
--- a/src/boss/boss_web_controller_handle_request.erl
+++ b/src/boss/boss_web_controller_handle_request.erl
@@ -285,7 +285,9 @@ process_not_found(Message, #boss_app_info{ router_pid = RouterPid } = AppInfo, R
                 {'EXIT', Reason} ->
                     {error, Reason};
                 {{ok, Payload, Headers}, _} ->
-                    {not_found, Payload, Headers}
+                    {not_found, Payload, Headers};
+                {{redirect,RedirectLocation,_},_} ->
+                    {redirect, RedirectLocation}
             end;
         {ok, OtherLocation} ->
             {redirect, OtherLocation};


### PR DESCRIPTION
With this patch we can modify 404 responses with before_filter in our application.

I'm not sure, if this is the right place to fix the issue, but it seems to work for me. I'll be happy with response from the team members.
