### PR TITLE
Modify JSON output code to take {X, Y, Z} as a date() rather than a now()

### DIFF
--- a/src/boss/boss_json.erl
+++ b/src/boss/boss_json.erl
@@ -49,7 +49,7 @@ json_data1([{VariableName, [[{_, _}|_]|_] = Variable}|Rest], ModelList, Acc) ->
 
 %% It's an erlang:now() value.
 json_data1([{VariableName, {A, B, C} = Val}|Rest], ModelList, Acc) when is_integer(A), is_integer(B), is_integer(C) ->
-    json_data1(Rest, ModelList, [{VariableName, iso8601:format(Val)}|Acc]);
+    json_data1(Rest, ModelList, [{VariableName, erlang:list_to_binary(io_lib:format("~b-~b-~b", [A, B, C]))}|Acc]);
 json_data1([{VariableName, Variable}|Rest], ModelList, Acc) ->
     case boss_model_manager:is_model_instance (Variable, ModelList) of
         true -> 

--- a/src/boss/model_manager_adapters/boss_model_manager_boss_db.erl
+++ b/src/boss/model_manager_adapters/boss_model_manager_boss_db.erl
@@ -59,8 +59,8 @@ to_json(Object) ->
   Data = lists:map (fun
     ({Attr, Val}) when is_list (Val) ->
        {Attr, list_to_binary (Val)};
-    ({Attr, {_,_,_} = Val}) ->
-       {Attr, iso8601:format(Val)};
+    ({Attr, {Yr, Mo, Da} = Val}) ->
+       {Attr, erlang:list_to_binary(io_lib:format("~b-~b-~b", [Yr, Mo, Da]))};
     ({Attr, {{_, _, _}, {_, _, _}} = Val}) ->
        {Attr, iso8601:format(Val)};
     (Other) ->


### PR DESCRIPTION
My experience (and business requirements) are that date() results are
much more common in model objects than now() objects.
