### PR TITLE
be abble to send a json response with a 404 handler

### DIFF
--- a/src/boss/boss_web_controller_handle_request.erl
+++ b/src/boss/boss_web_controller_handle_request.erl
@@ -285,7 +285,9 @@ process_not_found(Message, #boss_app_info{ router_pid = RouterPid } = AppInfo, R
                 {'EXIT', Reason} ->
                     {error, Reason};
                 {{ok, Payload, Headers}, _} ->
-                    {not_found, Payload, Headers}
+                    {not_found, Payload, Headers};
+                {{Code, Payload, Headers}, _} ->
+                    {Code, Payload, Headers}
             end;
         {ok, OtherLocation} ->
             {redirect, OtherLocation};


### PR DESCRIPTION
use case rest api:
 be abble to send a json response without to create a template, shorcut the rendering.

```
route file:
 {404, [{controller, "v1"}, {action, "not_found"}]}.
```

``` erlang
in controller v1
not_found('GET', _) ->
    {404, jsx:encode([{error, <<"Invalid Request">>}]), [{"Content-type","application/json"}]}.
```
