### PR TITLE
Support specs with Module:Type().

### DIFF
--- a/src/boss/boss_doc.erl
+++ b/src/boss/boss_doc.erl
@@ -178,4 +178,9 @@ analyze_argtypes_content([#xmlElement{ name = 'atom', attributes = Attrs }]) ->
 analyze_argtypes_content([#xmlElement{ name = 'abstype', content = 
             [#xmlElement{ name = erlangName, attributes = 
                     [#xmlAttribute{ name = 'name', value = Type }]}]}]) ->
-    "<span class=\"typevar\">::" ++ Type ++ "()</span>".
+    "<span class=\"typevar\">::" ++ Type ++ "()</span>";
+analyze_argtypes_content([#xmlElement{ name = 'abstype', content =
+            [#xmlElement{ name = erlangName, attributes =
+                    [#xmlAttribute{ name = 'module', value = ModuleName },
+                     #xmlAttribute{ name = 'name', value = Type }]}]}]) ->
+    "<span class=\"typevar\">::" ++ ModuleName ++ ":" ++ Type ++ "()</span>".


### PR DESCRIPTION
boss_db.erl has a function, `sort_order(Options)` with the following spec:

``` erlang
-spec(sort_order(jsx:json_term()) -> sort_order()).
```

This crashes `make edoc` violently, and this patch endeavours to add support for these cases.
