### PR TITLE
Fix boss web controller test

### DIFF
--- a/test/boss_web_controller_test.erl
+++ b/test/boss_web_controller_test.erl
@@ -15,7 +15,7 @@ wants_session(_Application, R, _Modules) ->
 
 call_controller_action_test() ->
     R = boss_web_controller:call_controller_action(?MODULE, exit,[]),
-    ?assertEqual( {output, "Error in controller, see console.log for details\n"}, R),
+    ?assertEqual( {error, "Error in controller, see console.log for details\n"}, R),
     ?assertEqual( ok, boss_web_controller:call_controller_action(?MODULE, return,[])).
 
 make_action_session_id_test() ->


### PR DESCRIPTION
When running tests, I spotted that `{output, Message}` was changed to `{error, Message}` in `boss_web_controller`, but not in tests. This commit fixes that little issue.