### PR TITLE
Fix badmatch, when using session and calling non existent action

### DIFF
--- a/src/boss/controller_adapters/boss_controller_adapter_pmod.erl
+++ b/src/boss/controller_adapters/boss_controller_adapter_pmod.erl
@@ -95,7 +95,7 @@ action({_, ExportStrings} = Info, RequestContext) ->
         4 ->
             ControllerInstance:ActionAtom(RequestMethod, Tokens, AuthInfo);
         _ ->
-	    {CMod, _} = ControllerInstance,
+	    CMod = element(1, ControllerInstance),
 	    lager:notice("[ChicagoBoss] The function ~p:~s/2 is not exported, "++
 			 "if in doubt add -export([~s/2])) to the module",
 			 [CMod, Action, Action]),


### PR DESCRIPTION
In `boss_controller_adapter_pmod:action/2` there was pattern match: `{CMod, _} = ControllerInstance`, which assumes, that `ControllerInstance` is two element tuple. Actually, it may be two element tuple `{CMod, RequestWrapper}` or three element tuple `{CMod, RequestWrapper, Session}`.

The line was in the code, that handled actions which did not exist. It should return `undefined`, which causes returning 404, but because of `badmatch`, it returned "Error in controller, see console.log for details".

Changing pattern match to `CMod = element(1, ControllerInstance)` handles both cases and solves the problem.