### PR TITLE
More Options for URL construction ( Retain query parameters and allow Key-Value pairs)

### DIFF
--- a/src/boss/boss_erlydtl_tags.erl
+++ b/src/boss/boss_erlydtl_tags.erl
@@ -5,7 +5,7 @@ url(Variables, Options) ->
     ListVars = lists:map(fun 
             ({K, V}) when is_binary(V) -> {K, binary_to_list(V)}; 
             ({K, V}) -> {K, V} 
-        end, Variables),
+        end, lists:flatten(Variables)),
     ThisApp = proplists:get_value(application, Options),
     LinkedApp = proplists:get_value(application, ListVars, ThisApp),
     LinkedAppAtom = list_to_atom(lists:concat([LinkedApp])),


### PR DESCRIPTION
In one of the requirements I needed all the Query Params for URL construction but this was impossible with current tag. 
To illustrate it more lets have this forum question https://groups.google.com/forum/#!msg/chicagoboss/IQ0d1DBKgAM/j8Asd8WPjTYJ where Evan Miller suggested/intended doing `{% url foo="bar" _req.query_params %}` . However this doesn't work as Variables get values like 
```
[
 {foo, <<"bar">>},
 [
  {first_param, "x"},
  {second_param, "y"}
 ]
].
```
which goes unhandled by `lists:map`.
This can be resolved if we do a `lists:flatten`.