### PR TITLE
Bumped versions in rebar.config and boss.app.src

### DIFF
--- a/skel/rebar.config
+++ b/skel/rebar.config
@@ -1,5 +1,5 @@
 {deps, [
-  {boss, ".*", {git, "git://github.com/ChicagoBoss/ChicagoBoss.git", {tag, "v0.8.13"}}}
+  {boss, ".*", {git, "git://github.com/ChicagoBoss/ChicagoBoss.git", {tag, "v0.8.15"}}}
 ]}.
 {plugin_dir, ["priv/rebar"]}.
 {plugins, [boss_plugin]}.

--- a/src/boss.app.src
+++ b/src/boss.app.src
@@ -1,7 +1,7 @@
 {application, boss,
     [
     {description, "Chicago Boss web framework, now serving three flavors of Comet"},
-    {vsn, "0.8.14"},
+    {vsn, "0.8.15"},
     {registered, [
         boss_mq, boss_mq_sup,
         boss_session, boss_session_sup,


### PR DESCRIPTION
Hi there,

I fixed #561 as well as #556. For #556 I would argue that the line in the rebar.config should be kept. In my opinion this makes it easier to share your project with others as they can just check your code out and run rebar. Especially if you put the deps folder into .gitignore like I do.