### PR TITLE
skel/Makefile: add test target for running functional tests

### DIFF
--- a/skel/Makefile
+++ b/skel/Makefile
@@ -10,6 +10,9 @@ compile:
 
 compile-app:
 	$(REBAR) boss c=compile
+	
+test:
+	$(REBAR) boss c=test_functional
 
 help:
 	@echo 'Makefile for your chicagoboss app                                      '
@@ -20,10 +23,11 @@ help:
 	@echo '   make compile                     compiles dependencies              '
 	@echo '   make compile-app                 compiles only your app             '
 	@echo '                                    (so you can reload via init.sh)    '
+	@echo '   make test                        runs functional tests              '
 	@echo '   make all                         get-deps compile compile-app       '
 	@echo '                                                                       '
 	@echo 'DEFAULT:                                                               '
 	@echo '   make all                                                            '
 	@echo '                                                                       '
 
-.PHONY: all get-deps compile compile-app help
+.PHONY: all get-deps compile compile-app help test


### PR DESCRIPTION
Given the skeleton project's Makefile automates some rebar directives, also add in a 'make test' for running functional tests.