### PR TITLE
boss_mail_driver_smtp: tune gen_smtp options for relays

### DIFF
--- a/src/boss/boss_mail_driver_smtp.erl
+++ b/src/boss/boss_mail_driver_smtp.erl
@@ -2,7 +2,7 @@
 -export([start/0, stop/1, deliver/5]).
 
 start() ->
-    OptionsBase = [{ssl, false}, {hostname, smtp_util:guess_FQDN()}, {retries, 1}],
+    OptionsBase = [{ssl, false}, {no_mx_lookups, true}, {hostname, smtp_util:guess_FQDN()}, {retries, 3}],
     {ok, OptionsBase ++ get_tls() ++ get_host() ++ get_port() ++ get_credentials()}.
 
 get_tls() ->


### PR DESCRIPTION
It appears that some relays like Gmail have issues when MX lookups
are performed. This issue has been longstanding in general, even
after RFCs 973 and 974 standardized the record. As such, set
no_mx_lookups to true and fall back on A records.

In addition, be more lenient with retry attempts, from only 1
to 3. This may help with boss_mail timeouts to SMTP relays.