### PR TITLE
Include and document missing/new boss_db options 'db_configure' and 'db_ssl'

### DIFF
--- a/skel/boss.config
+++ b/skel/boss.config
@@ -94,6 +94,7 @@
 %% db_database - The name of the database to connect to (if needed).
 %% db_cache_enable - Whether to enable the cache in boss_db. Defaults 
 %%   to false. Requires cache_enable to be set to true.
+%% db_configure - Database adapter specific configuration options. Defaults to [].
 
     {db_host, "localhost"},
     {db_port, 1978},
@@ -101,6 +102,14 @@
 %    {db_username, "boss"},
 %    {db_password, "boss"},
 %    {db_database, "boss"},
+%    {db_configure, []},
+
+%%  PostgreSQL only
+%%
+%% db_ssl - If enabled a secured SSL connection will be established to the database server. Requires db_ssl to be set to
+%%   true or required. Defaults to false.
+%%   See https://github.com/epgsql/epgsql/blob/2.0.0/README for more details.
+%    {db_ssl, required},
 
 %%  MongoDB only
 %%

--- a/src/boss/model_manager_adapters/boss_model_manager_boss_db.erl
+++ b/src/boss/model_manager_adapters/boss_model_manager_boss_db.erl
@@ -24,9 +24,9 @@ start() ->
                     {ok, Val} -> [{OptName, Val}|Acc];
                     _ -> Acc
                 end
-        end, [], [db_port, db_host, db_username, db_password, db_database, 
-            db_replication_set, db_read_mode, db_write_mode, 
-            db_write_host, db_write_host_port, db_read_capacity, 
+        end, [], [db_port, db_host, db_username, db_password, db_database, db_ssl, db_configure,
+            db_replication_set, db_read_mode, db_write_mode,
+            db_write_host, db_write_host_port, db_read_capacity,
             db_write_capacity, db_model_read_capacity, db_model_write_capacity]),
 
     DBAdapter = boss_env:get_env(db_adapter, mock),


### PR DESCRIPTION
This PR is related to ErlyORM/boss_db#234 which isn't included in the actual referenced `boss_db` version v0.8.16.1, so it's maybe better to merge this PR after a new `boss_db` version will be released.