### PR TITLE
Replace logging with OTP error_logger through lager counterpart functions

### DIFF
--- a/src/boss/boss_load.erl
+++ b/src/boss/boss_load.erl
@@ -54,7 +54,7 @@ load_all_modules(Application, TranslatorSupPid) ->
     load_all_modules(Application, TranslatorSupPid, undefined).
 
 load_all_modules(Application, TranslatorSupPid, OutDir) ->
-    lager:info("Loading application ~p", [Application]),
+    lager:debug("Loading application ~p", [Application]),
     [{_, TranslatorPid, _, _}]	= supervisor:which_children(TranslatorSupPid),
     
     Ops = make_ops_list(TranslatorPid),
@@ -305,7 +305,7 @@ compile_view_dir_erlydtl(Application, LibPath, Module, OutDir, TranslatorPid) ->
     ExtraTagHelpers	= boss_env:get_env(template_tag_modules, []),
     ExtraFilterHelpers	= boss_env:get_env(template_filter_modules, []),
 
-    lager:info("Compile Modules ~p  ~p", [LibPath, Module]),
+    lager:debug("Compile Modules ~p  ~p", [LibPath, Module]),
     Res = erlydtl:compile_dir(LibPath, Module,
                             [{doc_root, view_doc_root(LibPath)}, {compiler_options, []}, {out_dir, OutDir},
                              {custom_tags_modules, TagHelpers ++ ExtraTagHelpers ++ [boss_erlydtl_tags]},

--- a/src/boss/boss_router.erl
+++ b/src/boss/boss_router.erl
@@ -28,7 +28,6 @@ reload(Pid) ->
     gen_server:call(Pid, reload).
 
 route(Pid, Url) ->
-	error_logger:info_msg("Route: ~pUrl~n~p",[Url, erlang:get_stacktrace()]),
     gen_server:call(Pid, {route, Url}).
 
 unroute(Pid, Application, ControllerList, Controller, undefined, Params) ->

--- a/src/boss/boss_router_controller.erl
+++ b/src/boss/boss_router_controller.erl
@@ -92,7 +92,6 @@ handle_info(_Info, State) ->
 
 load(State) ->
     RoutesFile = boss_files:routes_file(State#state.application),
-    error_logger:info_msg("Loading routes from ~p ....", [RoutesFile]),
     case file:consult(RoutesFile) of
         {ok, OrderedRoutes} -> 
             lists:foldl(fun
@@ -135,7 +134,7 @@ load(State) ->
                         Number+1
                 end, 1, OrderedRoutes);
         Error -> 
-            error_logger:error_msg("Missing or invalid boss.routes file in ~p~n~p~n", [RoutesFile, Error])
+            lager:error("Missing or invalid boss.routes file in ~p; Error reason: ~p", [RoutesFile, Error])
     end.
 
 handle(StatusCode, State) ->
@@ -168,7 +167,6 @@ route(Url, State) ->
                     not_found
             end;
         _Rte = #boss_route{ application = App, controller = C, action = A, params = P } -> 
-            lager:info("Boss Route ~p ~p ~p ~p", [App, C, A, P]),
             ControllerModule = list_to_atom(boss_files:web_controller(App, C, State#state.controllers)),
             {Tokens, []}     = boss_controller_lib:convert_params_to_tokens(P, ControllerModule, list_to_atom(A)),
             {ok, {App, C, A, Tokens}}

--- a/src/boss/boss_service_worker.erl
+++ b/src/boss/boss_service_worker.erl
@@ -81,7 +81,7 @@ init([Handler, ServiceUrl]) when is_atom(Handler) ->
 	    boss_websocket_router:register(ServiceUrl, Handler),
 	    {ok, #state{handler=Handler, internal=Internal}}
     catch Class:Reason ->
-	    error_logger:error_msg(
+        lager:error(
 	      "** Boss Service Handler ~p terminating in init/0~n"
 	      "   for the reason ~p:~p~n"
 	      "** Stacktrace: ~p~n~n",
@@ -131,7 +131,7 @@ handle_cast({join_service, ServiceUrl, WebSocketId, Req, SessionId}, State) ->
 	    {stop, InternalReason, #state{handler=Handler, internal=NewInternal}}
 
 	catch Class:Reason ->
-		error_logger:error_msg(
+        lager:error(
 		  "** Boss Service Handler ~p terminating in join/0~n"
 		  "   for the reason ~p:~p~n"
   		  "ServiceUrl: ~p~n"
@@ -156,7 +156,7 @@ handle_cast({terminate_service, Reason, ServiceUrl, WebSocketId, Req, SessionId}
 	    {stop, InternalReason, #state{handler=Handler, internal=NewInternal}}
 		
     catch Class:Reason ->
-	    error_logger:error_msg(
+        lager:error(
 	      "** Handler ~p terminating in init/0~n"
 	      "   for the reason ~p:~p~n"
 	      "ServiceUrl: ~p~n"
@@ -180,7 +180,7 @@ handle_cast({incoming_msg, ServiceUrl, WebSocketId, Req, SessionId, Message}, St
 	{stop, _Reason, NewInternal} ->
 	    {stop, _Reason, #state{handler=Handler, internal=NewInternal}}		
     catch Class:Reason ->
-	    error_logger:error_msg(
+        lager:error(
 	      "** Boss Service Handler ~p terminating in handle_incoming/4~n"
 	      "   for the reason ~p:~p~n"
 	      "ServiceUrl: ~p~n"
@@ -204,7 +204,7 @@ handle_cast({broadcast, Message}, State) ->
 	{stop, _Reason, NewInternal} ->
 	    {stop, _Reason, #state{handler=Handler, internal=NewInternal}}
     catch Class:Reason ->
-	    error_logger:error_msg(
+        lager:error(
 	      "** Boss Service Handler ~p terminating in broadcast~n"
 	      "   for the reason ~p:~p~n"
 	      "Message    : ~p~n"
@@ -237,7 +237,7 @@ handle_info(_Info, State) ->
 	{stop, InternalReason, NewInternal} ->
 	    {stop, InternalReason, #state{handler=Handler, internal=NewInternal}}
     catch Class:Reason ->
-	    error_logger:error_msg(
+        lager:error(
 	      "** Handler ~p terminating in handle_info/2~n"
 	      "   for the reason ~p:~p~n"
 	      "** Stacktrace: ~p~n~n",
@@ -265,7 +265,7 @@ terminate(_Reason, _State) ->
 	ok ->
 	    ok
     catch Class:Reason ->
-	    error_logger:error_msg(
+        lager:error(
 	      "** Boss Service Handler ~p terminating in handle_info/0~n"
 	      "   for the reason ~p:~p~n"
 	      "** Stacktrace: ~p~n~n",

--- a/src/boss/boss_web_controller.erl
+++ b/src/boss/boss_web_controller.erl
@@ -198,7 +198,7 @@ stop_init_scripts(Application, InitData) ->
                            ScriptInitData ->
                                catch Module:stop(ScriptInitData)
                        end;
-                   Error -> error_logger:error_msg("Compilation of ~p failed: ~p~n", [File, Error])
+                   Error -> lager:error("Compilation of ~p failed: ~p", [File, Error])
                 end
         end, ok, boss_files:init_file_list(Application)).
 
@@ -213,7 +213,7 @@ process_compile_result(File, Acc, {ok, Module}) ->
     InitResult =  Module:init(),
     init_result(File, Acc, Module, InitResult);
 process_compile_result(File, Acc, Error) ->
-    error_logger:error_msg("Compilation of ~p failed: ~p~n", [File, Error]),
+    lager:error("Compilation of ~p failed: ~p", [File, Error]),
     Acc.
 
 init_result(_File, Acc, Module, {ok, Info}) ->
@@ -221,7 +221,7 @@ init_result(_File, Acc, Module, {ok, Info}) ->
 init_result(_File, Acc, Module, ok) ->
     [{Module, true}|Acc];
 init_result(File, Acc, _Module,Error) ->
-    error_logger:error_msg("Execution of ~p failed: ~p~n", [File, Error]),
+    lager:error("Execution of ~p failed: ~p", [File, Error]),
     Acc.
 
 generate_session_id(Request) ->

--- a/src/boss/boss_web_controller_handle_request.erl
+++ b/src/boss/boss_web_controller_handle_request.erl
@@ -20,7 +20,6 @@ handle_request(Req, RequestMod, ResponseMod, RouterAdapter) ->
     ApplicationForPath	= RouterAdapter:find_application_for_path(Request,
                                                                   FullUrl, 
                                                                   LoadedApplications),
-    lager:notice("ApplicationForPath ~p~n", [ApplicationForPath]),
     
     try
 	   handle_application(Req, ResponseMod, Request, FullUrl, ApplicationForPath, RouterAdapter)
@@ -174,11 +173,11 @@ handle_protocol(_)     -> identity.
 
 
 log_status_code(500, ErrorFormat, ErrorArgs) ->
-    error_logger:error_msg(ErrorFormat, ErrorArgs);
+    lager:error(ErrorFormat, ErrorArgs);
 log_status_code(404, ErrorFormat, ErrorArgs) ->
-    error_logger:warning_msg(ErrorFormat, ErrorArgs);
+    lager:warning(ErrorFormat, ErrorArgs);
 log_status_code(_, ErrorFormat, ErrorArgs) ->
-    error_logger:info_msg(ErrorFormat, ErrorArgs).
+    lager:info(ErrorFormat, ErrorArgs).
 
 process_stream_generator(_Req, _TransferEncoding, 'HEAD', _Generator, _Acc) ->
     ok;
@@ -294,7 +293,7 @@ process_not_found(Message, #boss_app_info{ router_pid = RouterPid } = AppInfo, R
     end.
 
 process_error(Payload, AppInfo, RequestContext, development, RouterAdapter) ->
-    error_logger:error_report(Payload),
+    lager:error("~p", [Payload]),
     ExtraMessage = case RouterAdapter:handle(AppInfo#boss_app_info.router_pid, 500) of
         not_found ->
             ["This message will appear in production; you may want to define a 500 handler in ", boss_files:routes_file(AppInfo#boss_app_info.application)];
@@ -304,7 +303,7 @@ process_error(Payload, AppInfo, RequestContext, development, RouterAdapter) ->
     boss_web_controller_render:render_error(io_lib:print(Payload), ExtraMessage, AppInfo, RequestContext);
     
 process_error(Payload, #boss_app_info{ router_pid = RouterPid } = AppInfo, RequestContext, Mode, RouterAdapter) ->
-    error_logger:error_report(Payload),
+    lager:error("~p", [Payload]),
     case RouterAdapter:handle(RouterPid, 500) of
         {ok, {Application, Controller, Action, Tokens}} when Application =:= AppInfo#boss_app_info.application ->
             ErrorLocation = {Controller, Action, Tokens},

--- a/src/boss/controller_adapters/boss_controller_adapter_pmod.erl
+++ b/src/boss/controller_adapters/boss_controller_adapter_pmod.erl
@@ -88,7 +88,7 @@ action({_, ExportStrings} = Info, RequestContext) ->
     Tokens		= proplists:get_value(tokens, RequestContext),
     AuthInfo		= proplists:get_value('_before', RequestContext, RequestContext),
     ActionAtom          = list_to_atom(Action),
-    lager:notice("Request Method: ~p, Tokens: ~p", [RequestMethod, Tokens]),
+
     case proplists:get_value(Action, ExportStrings) of
         3 ->
             ControllerInstance:ActionAtom(RequestMethod, Tokens);

--- a/src/boss/session_adapters/boss_session_adapter_mnesia.erl
+++ b/src/boss/session_adapters/boss_session_adapter_mnesia.erl
@@ -19,13 +19,13 @@ stop(_) ->
     ok.
 
 init(_) ->
-    error_logger:info_msg("Starting distributed session mnesia storage~n"),
+    lager:info("Starting distributed session mnesia storage"),
     ok = ensure_schema(),  % Expects Mnesia to be stopped
     mnesia:start(),
     %%Checks for table, after some time tries to recreate it
     case mnesia:wait_for_tables([?TABLE], ?TIMEOUT) of
         ok -> 
-            error_logger:info_msg("mnesia session table ok~n"),	
+            lager:debug("mnesia session table ok"),
             noop;
         {timeout,[?TABLE]} ->
             create_session_storage()		
@@ -92,9 +92,9 @@ ensure_schema() ->
 
 create_session_storage()->
     Nodes = mnesia_nodes(),
-    error_logger:info_msg("Creating mnesia table for nodes ~p~n",  [Nodes]),
+    lager:notice("Creating mnesia table for nodes ~p",  [Nodes]),
     case mnesia:create_table(?TABLE,[{disc_copies,  Nodes}, {attributes, record_info(fields, boss_session)}]) of
-        {aborted, Reason} -> error_logger:error_msg("Error creating mnesia table for sessions: ~p~n", [Reason]);
+        {aborted, Reason} -> lager:error("Error creating mnesia table for sessions: ~p", [Reason]);
         {atomic, ok} -> ok
     end.
 

--- a/src/boss/session_adapters/boss_session_adapter_pgsql.erl
+++ b/src/boss/session_adapters/boss_session_adapter_pgsql.erl
@@ -20,7 +20,7 @@ stop(_Conn) ->
     ok.
 
 init(_Options) ->
-    error_logger:info_msg("Starting distributed session Postgresql storage~n"),
+    lager:info("Starting distributed session Postgresql storage"),
 
     %% Do we have a session table?  If not, create it.
     case boss_db:table_exists(boss_session) of


### PR DESCRIPTION
In combination with the replacement, some `notice` logs are changed to `debug` level as they seemed IMHO not meant to be for production mode. Some logs are removed because they're duplicating some others, or didn't seem appropriate from the perspective of security aspects.

This is a version we use in production and I thought it would be nice to share, but I'm not sure what's the downside replacing the `error_logger` with `lager`. The code base seemed inconsistent with the different logging mechanisms, so any comments about this change would be much appreciated.