### PR TITLE
Adds documentation to skeleton boss.config

### DIFF
--- a/skel/boss.config
+++ b/skel/boss.config
@@ -207,6 +207,11 @@
 %% session_key - Cookie key for sessions. Defaults to "_boss_session".
 %% session_exp_time - Expiration time in seconds for the session
 %%   cookie. Defaults to 525600, i.e. 6 days, 2 hours.
+%% session_cookie_http_only - Instructs the web browser that the session
+%%   cookie can not be accessed by javascripts, reducing the impact of
+%%   XSS attacks.
+%% session_cookie_secure - Instructs the web browser that the session
+%%   cookie can only be sent over a secure connection.
 %% session_mnesia_nodes, for {session_adapter, mnesia} only - List of
 %%   Mnesia nodes, defaults to node(). 
 %% session_domain - (optional, sets the Domain=x cookie option), 


### PR DESCRIPTION
Documents the http_only and secure session cookie parameters.