### PR TITLE
Enables httponly for session cookies by default.

### DIFF
--- a/skel/boss.config
+++ b/skel/boss.config
@@ -217,7 +217,7 @@
     {session_adapter, mock},
     {session_key, "_boss_session"},
     {session_exp_time, 525600},
-    {session_cookie_http_only, false},
+    {session_cookie_http_only, true},
     {session_cookie_secure, false},
 %    {session_enable, true},
 %    {session_mnesia_nodes, [node()]}, % <- replace "node()" with a node name


### PR DESCRIPTION
See ChicagoBoss/ChicagoBoss#602