### PR TITLE
Clean some code leftovers which are obsolete since f04a6ab commit #548

### DIFF
--- a/priv/rebar/boss_rebar_eunit.erl
+++ b/priv/rebar/boss_rebar_eunit.erl
@@ -200,47 +200,6 @@ get_eunit_opts(Config) ->
 
     BaseOpts ++ rebar_config:get_list(Config, eunit_opts, []).
 
-eunit_config(Config) ->
-    EqcOpts = eqc_opts(),
-    PropErOpts = proper_opts(),
-
-    ErlOpts = rebar_config:get_list(Config, erl_opts, []),
-    EunitOpts = rebar_config:get_list(Config, eunit_compile_opts, []),
-    Opts0 = [{d, 'TEST'}] ++
-        ErlOpts ++ EunitOpts ++ EqcOpts ++ PropErOpts,
-    Opts = [O || O <- Opts0, O =/= no_debug_info],
-    Config1 = rebar_config:set(Config, erl_opts, Opts),
-
-    FirstErls = rebar_config:get_list(Config1, eunit_first_files, []),
-    rebar_config:set(Config1, erl_first_files, FirstErls).
-
-eqc_opts() ->
-    define_if('EQC', is_lib_avail(is_eqc_avail, eqc,
-                                  "eqc.hrl", "QuickCheck")).
-
-proper_opts() ->
-    define_if('PROPER', is_lib_avail(is_proper_avail, proper,
-                                     "proper.hrl", "PropEr")).
-
-define_if(Def, true) -> [{d, Def}];
-define_if(_Def, false) -> [].
-
-is_lib_avail(DictKey, Mod, Hrl, Name) ->
-    case erlang:get(DictKey) of
-        undefined ->
-            IsAvail = case code:lib_dir(Mod, include) of
-                          {error, bad_name} ->
-                              false;
-                          Dir ->
-                              filelib:is_regular(filename:join(Dir, Hrl))
-                      end,
-            erlang:put(DictKey, IsAvail),
-            ?DEBUG("~s availability: ~p\n", [Name, IsAvail]),
-            IsAvail;
-        IsAvail ->
-            IsAvail
-    end.
-
 perform_cover(Config, BeamFiles, SrcModules) ->
     perform_cover(rebar_config:get(Config, cover_enabled, false),
                   Config, BeamFiles, SrcModules).


### PR DESCRIPTION
@danikp sorry for the delay with my PR/fix for #548. I was a little busy and hadn't much time to complete it. This PR is only a complement to your commit f04a6ab, which cleans some code leftovers. These functions are no longer needed since they are now part of the `rebar_erlc_compiler:test_compile()` process itself.