### PR TITLE
Parameterise use of ssl for outgoing mail

### DIFF
--- a/src/boss/boss_load.erl
+++ b/src/boss/boss_load.erl
@@ -230,13 +230,14 @@ load_dir(Dir, Application, OutDir, Compiler) when is_function(Compiler) ->
             {error, ErrorList}
     end.
 
-%% Only serve files that end in ".erl"
+%% Only serve files that end in ".erl" or ".ex"
 
 list_files(Dir) ->
     case file:list_dir(Dir) of
     {ok, FileList} ->
        lists:filter(fun(String) ->
-                string:right(String, 4) == ".erl"
+                Ext = filename:extension(String),
+                lists:member(Ext, [".erl", ".ex"])
             end, FileList);
     _ ->
         []

--- a/src/boss/boss_mail_driver_smtp.erl
+++ b/src/boss/boss_mail_driver_smtp.erl
@@ -14,8 +14,16 @@
 -export([start/0, stop/1, deliver/5]).
 
 start() ->
-    OptionsBase = [{ssl, false}, {hostname, smtp_util:guess_FQDN()}, {retries, 1}],
-    {ok, OptionsBase ++ get_tls() ++ get_host() ++ get_port() ++ get_credentials()}.
+    OptionsBase = [{hostname, smtp_util:guess_FQDN()}, {retries, 1}],
+    {ok, OptionsBase ++ get_ssl() ++ get_tls() ++ get_host() ++ get_port() ++ get_credentials()}.
+
+get_ssl() ->
+    case application:get_env(mail_relay_use_ssl) of
+        {ok, Setting} ->
+            [{ssl, Setting}];
+        undefined ->
+            [{ssl, false}]
+    end.
 
 get_tls() ->
     case application:get_env(mail_relay_use_tls) of


### PR DESCRIPTION
Use of ssl is triggered by a new config parameter - {mail_relay_use_ssl, true}
Default behaviour is to NOT use ssl (as previously).
