### PR TITLE
Return untranslated string instead of `undefined` in runtime translation

### DIFF
--- a/src/boss/boss_translator_controller.erl
+++ b/src/boss/boss_translator_controller.erl
@@ -38,7 +38,7 @@ init(Options) ->
 handle_call({lookup, Key, Locale}, _From, State) ->
     Return = case dict:find(Locale, State#state.strings) of
         {ok, Dict} -> lookup_key(Key, Dict);
-        _ -> undefined
+        _ -> Key
     end,
     {reply, Return, State};
 
@@ -74,10 +74,10 @@ handle_info(_Info, State) ->
 lookup_key(Key, Dict) when is_binary(Key) ->
     case dict:find(binary_to_list(Key), Dict) of
         {ok, Trans} -> list_to_binary(Trans);
-        error -> undefined
+        error -> Key
     end;
 lookup_key(Key, Dict) ->
     case dict:find(Key, Dict) of
         {ok, Trans} -> Trans;
-        error -> undefined
+        error -> Key
     end.


### PR DESCRIPTION
When string is not found in dictionaries it is better to return untranslated string than `undefined` atom. For example a lot of people have almost empty .po file for English.