### PR TITLE
Return untranslated string instead of `undefined` in runtime translation

### DIFF
--- a/src/boss/boss_translator.erl
+++ b/src/boss/boss_translator.erl
@@ -50,6 +50,12 @@ reload_all(Pid) ->
 %% @spec fun_for(Locale::string()) -> TranslationFun::function() | none
 fun_for(Pid, Locale) ->
     case is_loaded(Pid, Locale) of
-        true -> fun(String) -> ?MODULE:lookup(Pid, String, Locale) end;
+        true ->
+            fun(String) ->
+                case ?MODULE:lookup(Pid, String, Locale) of
+                    undefined -> String;
+                    Else -> Else
+                end
+            end;
         false -> none
     end.


### PR DESCRIPTION
When string is not found in dictionaries it is better to return untranslated string than `undefined` atom.