### PR TITLE
Tweak body size determination for binary bodies in boss_web_test

### DIFF
--- a/src/boss/boss_web_test.erl
+++ b/src/boss/boss_web_test.erl
@@ -350,7 +350,7 @@ post_request_loop(AppInfo) ->
     receive
         {From, Uri, Headers, Body} ->
             erlang:put(mochiweb_request_body, Body),
-            erlang:put(mochiweb_request_body_length, length(Body)),
+            erlang:put(mochiweb_request_body_length, body_size(Body)),
             erlang:put(mochiweb_request_post, mochiweb_util:parse_qs(Body)),
             [{_, RouterPid, _, _}]	= supervisor:which_children(AppInfo#boss_app_info.router_sup_pid),
             [{_, TranslatorPid, _, _}]	= supervisor:which_children(AppInfo#boss_app_info.translator_sup_pid),
@@ -420,3 +420,12 @@ parse([Head|Tail], Body) ->
         {"Content-Type", "application/json"} -> mochijson2:decode(Body);
         _ -> parse(Tail, Body)
     end.
+
+%%--------------------------------------------------------------------
+%%% Internal functions
+%%--------------------------------------------------------------------
+
+body_size(Body) when is_list(Body) ->
+    length(Body);
+body_size(Body) when is_binary(Body) ->
+    byte_size(Body).


### PR DESCRIPTION
For binary bodies like JSON data read from a file, `erlang:length/1` is not working and the size must be determined rather through `erlang:byte_size/1`.