### PR TITLE
Include missing eiconv implicit dependency from gen_smtp

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -22,6 +22,10 @@
         {jaderl,                ".*",   {git, "git://github.com/erlydtl/jaderl.git",            {tag, "14a80dafd"}}},
         {lfe,                   ".*",   {git, "git://github.com/rvirding/lfe.git",              {tag, "fb7c96eb17"}}},
         {gen_smtp,              ".*",   {git, "git://github.com/Vagabond/gen_smtp.git",         {tag, "fd0426c464"}}},
+        %% eiconv is declared as a testing dependency in gen_smtp and used from its MIME encoder/decoder, because of
+        %% CB usage of the MIME decoder in boss_smtp_server/boss_mail_driver_mock it must be declared explicitly
+        {eiconv,                ".*",   {git, "git://github.com/zotonic/eiconv.git",            {tag, "644fb5e7bd"}}},
+
         {mochiweb,              ".*",   {git, "git://github.com/mochi/mochiweb.git",            {tag, "v2.7.0"}}},
         {simple_bridge,         ".*",   {git, "git://github.com/nitrogen/simple_bridge.git",    {tag, "v1.4.1"}}},
         {cowboy,                ".*",   {git, "git://github.com/ninenines/cowboy.git",          {tag, "1.0.1"}}},


### PR DESCRIPTION
`eiconv` is declared as a testing dependency in gen_smtp and used from its MIME encoder/decoder, because of CB usage of the MIME decoder in `boss_smtp_server` / `boss_mail_driver_mock` it must be declared explicitly.