### PR TITLE
Include missing eiconv implicit dependency from gen_smtp

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -24,6 +24,9 @@
         {erlydtl,               ".*",   {git, "https://github.com/erlydtl/erlydtl.git",           {tag, "067a109"}}},
         {jaderl,                ".*",   {git, "https://github.com/erlydtl/jaderl.git",            {tag, "14a80dafd"}}},
         {gen_smtp,              ".*",   {git, "https://github.com/Vagabond/gen_smtp.git",         {tag, "0.11.0"}}},
+        %% eiconv is declared as a testing dependency in gen_smtp and used from its MIME encoder/decoder, because of
+        %% CB usage of the MIME decoder in boss_smtp_server/boss_mail_driver_mock it must be declared explicitly
+        {eiconv,                ".*",   {git, "https://github.com/zotonic/eiconv.git",            {tag, "644fb5e7bd"}}},
         {iso8601,               ".*",   {git, "https://github.com/danikp/erlang_iso8601.git",     {tag, "ae6a052017"}}},
         {mimetypes,             ".*",   {git, "https://github.com/spawngrid/mimetypes.git",       {branch, master}}},
 


### PR DESCRIPTION
`eiconv` is declared as a testing dependency in gen_smtp and used from its MIME encoder/decoder, because of CB usage of the MIME decoder in `boss_smtp_server` / `boss_mail_driver_mock` it must be declared explicitly.