### PR TITLE
Update simple_bridge to fix file multipart upload vulnerability

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -33,8 +33,8 @@
         %% webmachine still requires dispacher to be written for it
         %{webmachine,            ".*",   {git, "https://github.com/webmachine/webmachine.git",     {tag, "086bd10920"}}},
         %% yaws requires libpam0g-dev, for ubuntu install it with 'sudo apt-get install libpam0g-dev'
-        %{yaws,                  ".*",   {git, "https://github.com/klacke/yaws.git",               {tag, "yaws-2.0"}}},
-        {simple_bridge,         ".*",   {git, "https://github.com/nitrogen/simple_bridge.git",    {tag, "f64788d3bc"}}}
+        %{yaws,                  ".*",   {git, "https://github.com/klacke/yaws.git",               {tag, "yaws-2.0.2"}}},
+        {simple_bridge,          ".*",   {git, "https://github.com/nitrogen/simple_bridge.git",    {tag, "19af47fcc1"}}}
 
         %%% EXPERIMENTAL %%%
         %% Uncomment the following line if you want LFE support


### PR DESCRIPTION
`simple_bridge` should be updated to the latest master in order to fix some possible vulnerability at the file multipart endpoint as specified in https://github.com/nitrogen/simple_bridge/pull/62.
I've run `make test` locally without any problems but had no chance so far to test the version update on a fully functional project. The fix itself doesn't bring any incompatible changes to the API or request object, but maybe someone with deeper CB inside knowledge can better oversee the rest of changes - see [simple_bridge changes](https://github.com/nitrogen/simple_bridge/compare/f64788d3bc...19af47fcc1).