### PR TITLE
Fix #650 - No time in modules compiled by Erlang 19.0 

### DIFF
--- a/src/boss/boss_controller_compiler.erl
+++ b/src/boss/boss_controller_compiler.erl
@@ -68,7 +68,7 @@ compile(File) ->
     compile(File, []).
 
 compile(File, Options) ->
-    _ = lager:info("Compile controller ~s", [File]),
+%    _ = lager:info("Compile controller ~s", [File]),
     boss_compiler:compile(File,
                           [debug_info,{pre_revert_transform, fun ?MODULE:add_routes_to_forms/1}|Options]).
 


### PR DESCRIPTION
This implements Jesse's suggestion of simply comparing last-modified date for the source with that for the beam file. (Although he describes it as "low-tech" half the universe is based on this technique, so I have no issues with it.)

Note that to do this, files are always compiled to disk.